### PR TITLE
Add the docker extra to the installation of molecule

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,7 @@
-docker # Needed for molecule to work correctly
-flake8
 # Temporarily use the latest molecule from master.  The latest release
 # of molecule does not play well with ansible 2.8.  We will revert
 # this once a new release comes out.
 #
-# Also install flake8, since it appears to be missing from the
-# dependencies for the bleeding edge molecule.
-# molecule
-git+https://github.com/ansible/molecule.git#egg=molecule
+# molecule[docker]
+git+https://github.com/ansible/molecule.git#egg=molecule[docker]
 pre-commit


### PR DESCRIPTION
This gets rid of the need to install the docker python module separately.

flake8 is now a dependency of the latest molecule, so there is no need to install it separately either.