### PR TITLE
Add support for Debian Buster

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,7 @@ galaxy_info:
     - name: Debian
       versions:
         - stretch
+        - buster
     - name: Amazon
       versions:
         - 2018.03

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,6 +8,8 @@ lint:
 platforms:
   - name: debian9
     image: debian:stretch-slim
+  - name: debian10
+    image: debian:buster-slim
   - name: amazon2018.03
     image: amazonlinux:2018.03
 provisioner:


### PR DESCRIPTION
Buster is scheduled to be released today.  Buster also includes the `freeipa-client` package, while Stretch does not, so switching to Buster would make our lives a lot easier going forward.