### PR TITLE
Use a prerelease of molecule instead of the latest from master

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,5 @@
-# Temporarily use the latest molecule from master.  The latest release
-# of molecule does not play well with ansible 2.8.  We will revert
-# this once a new release comes out.
-#
-# molecule[docker]
-git+https://github.com/ansible/molecule.git#egg=molecule[docker]
+# Temporarily use a prerelease of molecule.  The latest release of
+# molecule does not play well with ansible 2.8.  We will revert this
+# once a new release comes out.
+molecule[docker] >= 2.22rc3
 pre-commit


### PR DESCRIPTION
The latest from molecule's `master` branch is currently broken, but the latest prerelease has all the goodies we need.   Once a new release is made we will use that instead.