### PR TITLE
Add GitHub Action caches for pip and pre-commit, split workflow into two jobs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: build
 
 on: [push]
 
+env:
+  PIP_CACHE_DIR: ~/.cache/pip
+  PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +18,23 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
+
+      - name: Cache pip test requirements
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.PIP_CACHE_DIR }}
+          key: "${{ runner.os }}-pip-test-\
+            ${{ hashFiles('**/requirements-test.txt') }}"
+          restore-keys: |
+            ${{ runner.os }}-pip-test-
+            ${{ runner.os }}-pip-
+
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.PRE_COMMIT_CACHE_DIR }}
+          key: "${{ runner.os }}-pre-commit-\
+            ${{ hashFiles('**/.pre-commit-config.yaml') }}"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ env:
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
 
@@ -43,6 +42,31 @@ jobs:
 
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Cache pip test requirements
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.PIP_CACHE_DIR }}
+          key: "${{ runner.os }}-pip-test-\
+            ${{ hashFiles('**/requirements-test.txt') }}"
+          restore-keys: |
+            ${{ runner.os }}-pip-test-
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r requirements-test.txt
 
       - name: Run molecule tests
         run: molecule test


### PR DESCRIPTION
- Add GitHub Action caches for pip and pre-commit.
- Split workflow into `lint`, and `test` jobs to speed things up.

This closes #24  
