### PR TITLE
Add a custom Dockerfile for Debian 9 that forces python2

### DIFF
--- a/molecule/default/Dockerfile_debian_9.j2
+++ b/molecule/default/Dockerfile_debian_9.j2
@@ -1,0 +1,12 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+ARG testarg=fail
+ENV envarg=$testarg
+
+RUN apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 python-apt aptitude && apt-get clean

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     image: amazonlinux:2
   - name: debian9
     image: debian:stretch-slim
+    dockerfile: Dockerfile_debian_9.j2
   - name: debian10
     image: debian:buster-slim
   - name: debian11


### PR DESCRIPTION
## 🗣 Description

Add a custom Dockerfile for Debian 9 that forces python2.  (The default Dockerfile provided with molecule installs python3 for all Debian distros.)

## 💭 Motivation and Context

This is necessary to ensure the CyHy AMIs (which are the only ones still built on Debian 9) continue to build as expected.  Once CyHy is ported to python3 we can drop support for Debian 9.

## 🧪 Testing

One can verify via the molecule (really ansible) output that the Debian 9 molecule image is now built with python2 installed instead of python3.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
