### PR TITLE
Support only Fedora 32 and 33

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,12 +19,9 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - 29
-        # Ansible currently insists on installing python2-dnf, which
-        # does not exist in Fedora 30.  Until that is resolved, we
-        # can't use Fedora 30.
-        # - 30
         - 31
+        - 32
+        - 33
     - name: Ubuntu
       versions:
         - bionic

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
         - bullseye
     - name: Fedora
       versions:
-        - 31
         - 32
         - 33
     - name: Ubuntu

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,15 +20,12 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora29
-    image: fedora:29
-  # Ansible currently insists on installing python2-dnf, which does
-  # not exist in Fedora 30.  Until that is resolved, we can't use
-  # Fedora 30.
-  # - name: fedora30
-  #   image: fedora:30
   - name: fedora31
     image: fedora:31
+  - name: fedora32
+    image: fedora:32
+  - name: fedora33
+    image: fedora:33
   - name: ubuntu16
     image: ubuntu:xenial
   - name: ubuntu18

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,8 +20,6 @@ platforms:
     image: debian:bullseye-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora31
-    image: fedora:31
   - name: fedora32
     image: fedora:32
   - name: fedora33


### PR DESCRIPTION
## 🗣 Description

This pull request removes support for Fedora 29 and adds support for Fedora 32 and 33.

## 💭 Motivation and Context

Fedora 29 is no longer supported by the Fedora folks, so it shouldn't
be supported by us either.

[cisagov/freeipa-server-packer now supports Fedora 32](https://github.com/cisagov/freeipa-server-packer/pull/20), so we drop support for Fedora 31 as well.

## 🧪 Testing

No testing is necessary, only executive decision making abilities.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
