### PR TITLE
Add a prepare playbook that imports the update and python playbooks

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,6 @@
+---
+- name: Import upgrade playbook
+  import_playbook: upgrade.yml
+
+- name: Import python playbook
+  import_playbook: python.yml

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  name: Install pip3/python3 and remove pip2/python2
+  become: yes
+  become_method: sudo
+  roles:
+    - pip
+    - python
+    - remove_python2

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,8 @@
+- src: https://github.com/cisagov/ansible-role-pip
+  name: pip
+- src: https://github.com/cisagov/ansible-role-python
+  name: python
+- src: https://github.com/cisagov/ansible-role-remove-python2
+  name: remove_python2
+- src: https://github.com/cisagov/ansible-role-upgrade
+  name: upgrade

--- a/molecule/default/upgrade.yml
+++ b/molecule/default/upgrade.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  name: Upgrade base image
+  become: yes
+  become_method: sudo
+  roles:
+    - upgrade


### PR DESCRIPTION
## 🗣 Description

This pull request adds a prepare playbook that imports the update and python playbooks we use when building AMIs via packer.

Note that it may be possible to drop the python playbook once both:
* Python2 and Python3 are no longer co-existing in the distros we use
* Ansible no longer insists on using `/usr/bin/python` if it exists

## 💭 Motivation and Context

This upgrades the base image, installs python3/pip3, and removes python2/pip2.  This leaves the base image in a state just like it would be if we were building an AMI via Packer, and is a much more realistic canvas on which to perform our molecule tests.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
