### PR TITLE
Add three dashes to the top of the requirements YAML file

### DIFF
--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,4 @@
+---
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
 - src: https://github.com/cisagov/ansible-role-python


### PR DESCRIPTION
## 🗣 Description

This pull request adds three dashes to the top of the requirements YAML file.

## 💭 Motivation and Context

Any YAML file should start with three dashes.  This was an oversight on my part in #48.

I think we added the three dashes when dealing with the lineage Kraken after #48, so merging this PR should just generate a bunch of empty PRs for `ansible-role-*` repos, which I can shepherd through the approval process.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
