### PR TITLE
Define role_name in metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,8 @@ galaxy_info:
   author: First Last
   description: Skeleton Ansible role
   company: CISA Cyber Assessments
+  galaxy_tags:
+    - skeleton
   license: CC0
   min_ansible_version: 2.0
   platforms:
@@ -25,7 +27,6 @@ galaxy_info:
       versions:
         - bionic
         - xenial
-  galaxy_tags:
-    - skeleton
+  role_name: skeleton
 
 dependencies: []


### PR DESCRIPTION
## 🗣 Description

In this pull request I:
* Add a `role_name` entry to the Ansible role metadata.
* Alphabetize the metadata entries by key.

## 💭 Motivation and Context

`ansible-lint` now enforces that Ansible role names conform to the requirements for Ansible collection role names, defined [here](https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html#roles-directory).

Note that this excludes the use of the `-` character, which means that any Ansible roles using the old naming scheme of `ansible-role-*` now trigger an `ansible-lint` error.  This has caused [a lot of woe](https://github.com/ansible/ansible-lint/issues/966).

Fortunately, there is [an issue](https://github.com/ansible/ansible-lint/issues/979) and a corresponding [pull request with a fix](https://github.com/ansible/ansible-lint/pull/980).  That pull request has been merged and has made its way into the 4.3.2 release of `ansible-lint`.

In short, by default `ansible-lint` assumes that the role name is the name of the directory containing the role, but one is allowed to override this behavior by setting the `role_name` entry in the role metadata.  That will satisfy `ansible-lint`, and that is what I have done here.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
