### PR TITLE
Require the use of a recent version of Ansible and add support for Ubuntu 20

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,8 +30,8 @@ galaxy_info:
         - 33
     - name: Ubuntu
       versions:
-        - bionic
         - xenial
+        - bionic
   role_name: skeleton
 
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,12 @@ galaxy_info:
   galaxy_tags:
     - skeleton
   license: CC0
-  min_ansible_version: 2.0
+  # With the release of version 2.10, Ansible finally correctly
+  # identifies Kali Linux as being the Kali distribution of the Debian
+  # OS family.  This simplifies a lot of things for roles that support
+  # Kali Linux, so it makes sense to force the installation of Ansible
+  # 2.10 or newer.
+  min_ansible_version: 2.10
   platforms:
     - name: Amazon
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
       versions:
         - xenial
         - bionic
+        - focal
   role_name: skeleton
 
 dependencies: []

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -28,6 +28,8 @@ platforms:
     image: ubuntu:xenial
   - name: ubuntu18
     image: ubuntu:bionic
+  - name: ubuntu20
+    image: ubuntu:focal
 provisioner:
   name: ansible
   config_options:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,10 @@
 --requirement requirements.txt
+# With the release of version 2.10, Ansible finally correctly
+# identifies Kali Linux as being the Kali distribution of the Debian
+# OS family.  This simplifies a lot of things for roles that support
+# Kali Linux, so it makes sense to force the installation of Ansible
+# 2.10 or newer.
+ansible>=2.10,<3
 ansible-lint
 flake8
 molecule[docker]


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Adds a requirement for a recent (post-2.10) version of Ansible
* Adds support for Ubuntu 20

## 💭 Motivation and Context

With the release of version 2.10, Ansible (finally) correctly identifies Kali Linux as being the `Kali` distribution of the `Debian` OS family.  This simplifies a lot of things for roles that support Kali Linux, so it makes sense to force the installation of Ansible 2.10 or newer.

Ubuntu 20 was released in April of this year, so we are overdue for adding it to the list of Linux distributions that we support.  We will leave support for Ubuntu 16 and Ubuntu 18 since both are widely supported.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
