### PR TITLE
Force the use of auto_legacy for Debian 9

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -37,6 +37,35 @@ provisioner:
       # space and the slash.  This option converts those characters to
       # underscores when creating the group name.
       force_valid_group_names: always
+  inventory:
+    host_vars:
+      debian9:
+        # auto_legacy is still the default behavior until Ansible 2.12
+        # is released, but Molecule overrides this and forces the use
+        # of auto.
+        #
+        # In auto_legacy mode Ansible will prefer the /usr/bin/python
+        # interpreter if it exists, while in auto mode it will prefer
+        # the Python interpreter specified in an internal map.  In
+        # most cases we only have Python3 installed, and the internal
+        # map specifies /usr/bin/python3, so it is immaterial whether
+        # we use auto_legacy or auto.
+        #
+        # The one place where it _does_ matter is our Debian9 AKA CyHy
+        # instances.  Here the /usr/bin/python _and_ /usr/bin/python3
+        # interpreters are both installed.  In Ansible 2.10 a Debian
+        # entry was added to the internal map, so now auto_legacy
+        # selects the /usr/bin/python interpreter while auto selects
+        # the /usr/bin/python3 interpreter.  We want to maintain the
+        # auto_legacy behavior in this case since CyHy is still
+        # Python2.
+        #
+        # See:
+        # * https://github.com/ansible-community/molecule/blob/3.0.8/molecule/provisioner/ansible.py#L389
+        # * https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/config/base.yml#L1492-L1542
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/executor/interpreter_discovery.py
+        ansible_python_interpreter: auto_legacy
 scenario:
   name: default
 verifier:


### PR DESCRIPTION
## 🗣 Description

In this pull request I add a host variable to force the use of `auto_legacy` for the `ansible_python_interpreter` variable for Debian 9 (Stretch).

## 💭 Motivation and Context

[`auto_legacy` is still the default behavior until Ansible 2.12 is released](https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery), but [Molecule overrides this and forces the use of `auto`](https://github.com/ansible-community/molecule/blob/3.0.8/molecule/provisioner/ansible.py#L389).

In `auto_legacy` mode Ansible will prefer the `/usr/bin/python` interpreter if it exists, while in `auto` mode it will prefer the Python interpreter specified in an internal map.  In most cases we only have Python3 installed, and the internal map specifies `/usr/bin/python3`, so it is immaterial whether we use `auto_legacy` or `auto`.

The one place where it _does_ matter is our Debian9 AKA CyHy instances.  Here the `/usr/bin/python` _and_ `/usr/bin/python3` interpreters are both installed.  In Ansible 2.10 a `debian` entry was added to the internal map, so now `auto_legacy` selects the `/usr/bin/python` interpreter while `auto` selects the `/usr/bin/python3` interpreter.  We want to maintain the `auto_legacy` behavior in this case since CyHy is still Python2.

See also [the relevant Ansible configuration variables](https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/config/base.yml#L1492-L1542) as well as [the Ansible source code where they are used](https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/executor/interpreter_discovery.py).

## 🧪 Testing

All molecule tests and pre-commit hooks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
