### PR TITLE
Fix several places where I neglected to remove references to PY_VERSION env var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,23 +48,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - id: setup-python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Store installed Python version
-        run: |
-          echo "PY_VERSION="\
-          "$(python -c "import platform;print(platform.python_version())")" \
-          >> $GITHUB_ENV
       - name: Cache testing environments
         uses: actions/cache@v2
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: "test-${{ runner.os }}-py${{ env.PY_VERSION }}-\
-            ${{ hashFiles('**/requirements-test.txt') }}-\
-            ${{ hashFiles('**/requirements.txt') }}"
+          key: "test-${{ runner.os }}-\
+          py${{ steps.setup-python.outputs.python-version }}-\
+          ${{ hashFiles('**/requirements-test.txt') }}-\
+          ${{ hashFiles('**/requirements.txt') }}"
           restore-keys: |
-            test-${{ runner.os }}-py${{ env.PY_VERSION }}-
+            test-${{ runner.os }}-\
+            py${{ steps.setup-python.outputs.python-version }}-
             test-${{ runner.os }}-
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## 🗣 Description ##

In this pull request I fix several places in the GitHub Actions workflows where I neglected to remove references to the `PY_VERSION` environment variable.

## 💭 Motivation and Context ##

This should have been done as part of merging in the latest lineage pull request.

## 🧪 Testing ##

All GitHub Actions pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All new and existing tests pass.
