### PR TITLE
Rename testinfra to pytest-infra in Python requirements file

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,5 +9,5 @@ ansible-lint
 flake8
 molecule[docker]
 pre-commit
-testinfra
+pytest-testinfra
 yamllint


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes the name of a Python module in a requirements file from `testinfra` to `pytest-testinfra`.

## 💭 Motivation and Context ##

The name of the Python module [has changed upstream](https://pypi.org/project/testinfra/).

If we use the old package name then we get a warning like this when running the "verify" stage of `molecule`:
```console
--> Action: 'verify'
--> Executing Testinfra tests found in /home/runner/work/ansible-role-docker/ansible-role-docker/molecule/default/tests/...
/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/site-packages/_testinfra_renamed.py:5: DeprecationWarning: testinfra package has been renamed to pytest-testinfra. Please `pip install pytest-testinfra` and `pip uninstall testinfra` and update your package requirements to avoid this message
```

## 🧪 Testing ##

After making this change, I verified that:
* All `pre-commit` hooks pass
* The warning mentioned above is no longer present when running `molecule`
* All `molecule` tests pass

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
