### PR TITLE
Remove unnecessary Ansible configuration option

### DIFF
--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -39,13 +39,6 @@ platforms:
     image: ubuntu:focal
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      # The OS family and distribution for Kali is "Kali GNU/Linux",
-      # which is not an allowable group name in Ansible due to the
-      # space and the slash.  This option converts those characters to
-      # underscores when creating the group name.
-      force_valid_group_names: always
   inventory:
     host_vars:
       debian9:

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -87,13 +87,6 @@ platforms:
     pre_build_image: yes
 provisioner:
   name: ansible
-  config_options:
-    defaults:
-      # The OS family and distribution for Kali is "Kali GNU/Linux",
-      # which is not an allowable group name in Ansible due to the
-      # space and the slash.  This option converts those characters to
-      # underscores when creating the group name.
-      force_valid_group_names: always
   inventory:
     host_vars:
       debian9_systemd:


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the now-unnecessary `force_valid_group_names` Ansible configuration option.

## 💭 Motivation and Context ##

Ansible (as of 2.10) now correctly identifies Kali Linux as the Kali distribution of Debian, so it is no longer necessary to force valid group names.

## 🧪 Testing ##

All `molecule` tests and `pre-commit` hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
