### PR TITLE
Remove Support for Ubuntu Xenial (16) Hosts

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,7 +30,6 @@ galaxy_info:
         - 33
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
   role_name: skeleton

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -31,8 +31,6 @@ platforms:
     image: fedora:32
   - name: fedora33
     image: fedora:33
-  - name: ubuntu16
-    image: ubuntu:xenial
   - name: ubuntu18
     image: ubuntu:bionic
   - name: ubuntu20

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -64,13 +64,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu_16_systemd
-    image: geerlingguy/docker-ubuntu1604-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
   - name: ubuntu_18_systemd
     image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: yes


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes Ubuntu Xenial (16.04 LTS) from our supported platforms.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The primary driver for this change is due to Python. Xenial's latest `python-pip`/`python3-pip` package version is `8.1.1`, and the latest `python3` package is `3.5.1`. The important interaction here is that `pip < 9` does not support [PEP 503](https://www.python.org/dev/peps/pep-0503/), which exposes the [PEP 345 `Requires-Python`](https://www.python.org/dev/peps/pep-0345/#requires-python) metadata field. As newer version of Python packages move to support only Python 3.6+, they rely on this metadata to prevent installation in environments with incompatible Python versions. This has finally reared its head because of the [setuptools](https://github.com/pypa/setuptools) package, which dropped support for Python 3.5 in [v51.0.0](https://setuptools.readthedocs.io/en/latest/history.html#v51-0-0). This has resulted in `pip` failing during package installation in some of our workflows:
https://github.com/cisagov/ansible-role-cyhy-runner/runs/1777616284?check_suite_focus=true#step:6:449

```log
Traceback (most recent call last):
  File \"<string>\", line 1, in <module>
  File \"/tmp/pip-sgf48evr-build/setup.py\", line 107, in <module>
    entry_points={\"console_scripts\": [\"cyhy-runner = cyhy_runner.cyhy_runner:main\"]},
  File \"/usr/local/lib/python3.5/dist-packages/setuptools/__init__.py\", line 153, in setup
    return distutils.core.setup(**attrs)
  File \"/usr/lib/python3.5/distutils/core.py\", line 148, in setup
    dist.run_commands()
  File \"/usr/lib/python3.5/distutils/dist.py\", line 955, in run_commands
    self.run_command(cmd)
  File \"/usr/lib/python3.5/distutils/dist.py\", line 974, in run_command
    cmd_obj.run()
  File \"/usr/local/lib/python3.5/dist-packages/setuptools/command/install.py\", line 61, in run
    return orig.install.run(self)
  File \"/usr/lib/python3.5/distutils/command/install.py\", line 595, in run
    self.run_command(cmd_name)
  File \"/usr/lib/python3.5/distutils/cmd.py\", line 313, in run_command
    self.distribution.run_command(command)
  File \"/usr/lib/python3.5/distutils/dist.py\", line 974, in run_command
    cmd_obj.run()
  File \"/usr/local/lib/python3.5/dist-packages/setuptools/command/install_scripts.py\", line 17, in run
    import setuptools.command.easy_install as ei
  File \"/usr/local/lib/python3.5/dist-packages/setuptools/command/easy_install.py\", line 719
    ):
    ^
SyntaxError: invalid syntax
```

Since Xenial loses standard support in April of this year (2021), and goes End-of-Life in April of 2024 per the [Ubuntu Releases page](https://wiki.ubuntu.com/Releases), it doesn't make sense to try and work around this issue for a platform we aren't actively using.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass fine.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
