### PR TITLE
Pin ansible-lint Version Under the 5.0 Release

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,11 @@
 # Kali Linux, so it makes sense to force the installation of Ansible
 # 2.10 or newer.
 ansible>=2.10,<3
-ansible-lint
+# ansible-lint has a number of breaking changes with the update to v5 as we have
+# documented in https://github.com/cisagov/skeleton-ansible-role/issues/69
+# We can unpin once everything with the v5 update has shaken out and we have a
+# clear path forward.
+ansible-lint<5
 flake8
 molecule[docker]
 pre-commit


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a pin to [ansible-lint](https://github.com/ansible-community/ansible-lint) to keep us from using `v5`, which released on 2021-02-09.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As mentioned in #69 , the `v5` release has a number of issues that need to be resolved before you can begin using it in your Ansible projects. Until there is a clear path forward it is best for us to hold off on `v5` for the immediate future. Once we have that path, then we should revisit to unpin this requirement.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
