### PR TITLE
Use a matrix strategy for running single or multiple Molecule scenarios

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,11 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - default
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -134,7 +139,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
       - name: Run molecule tests
-        run: molecule test
+        run: molecule test --scenario-name ${{ matrix.scenario }}
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the GitHub Actions workflow to use a matrix strategy for running a single or multiple Molecule scenarios.

## 💭 Motivation and context ##

By default we only have the single default scenario, but there are some cisagov/ansible-role-* repos (i.e. [cisagov/ansible-role-xfce-cool](https://github.com/cisagov/ansible-role-xfce-cool)) where we run multiple scenarios.  In those cases it makes sense to run them in a matrix since they will run in parallel; hence it makes sense to go ahead and add the scaffolding to support that, so folks handle multiple scenarios correctly going forward.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
