### PR TITLE
Use the geerlingguy/docker-debian11-ansible Image

### DIFF
--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -37,7 +37,7 @@ platforms:
     command: /lib/systemd/systemd
     pre_build_image: yes
   - name: debian11_systemd
-    image: cisagov/docker-debian11-ansible:latest
+    image: geerlingguy/docker-debian11-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR switches us from using the [cisagov/docker-debian11-ansible](https://github.com/cisagov/docker-debian11-ansible) image to the [geerlingguy/docker-debian11-ansible](https://github.com/geerlingguy/docker-debian11-ansible) image for [molecule](https://github.com/ansible-community/molecule) testing.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [cisagov/docker-debian11-ansible](https://github.com/cisagov/docker-debian11-ansible) project was made because there was no geerlingguy image and we needed to support the platform. Now that there is an "official" image we should use it to align with our other `systemd` images used for testing.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automatic tests pass.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
