### PR TITLE
Unpin ansible-lint

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@
 # Kali Linux, so it makes sense to force the installation of Ansible
 # 2.10 or newer.
 ansible>=2.10,<5
-ansible-lint
+ansible-lint>=5,<6
 flake8
 molecule[docker]
 pre-commit

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,11 +5,7 @@
 # Kali Linux, so it makes sense to force the installation of Ansible
 # 2.10 or newer.
 ansible>=2.10,<5
-# ansible-lint has a number of breaking changes with the update to v5 as we have
-# documented in https://github.com/cisagov/skeleton-ansible-role/issues/69
-# We can unpin once everything with the v5 update has shaken out and we have a
-# clear path forward.
-ansible-lint<5
+ansible-lint
 flake8
 molecule[docker]
 pre-commit


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Unpins `ansible-lint` (it was previously restricted to be `<5`)
- Adds a configuration file for `ansible-lint`
- Adds a `cisagov` namespace to the role metadata

## 💭 Motivation and context ##

We have been avoiding version 5 of `ansible-lint` for a while because it introduced some breaking changes.  The dust has now settled, and I have a way forward (thanks to @geerlingguy).

Resolves #69.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
