### PR TITLE
Update `ansible-lint` Configuration

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,9 +13,6 @@ exclude_paths:
   - .cache
   # Seems wise to ignore this too
   - .github
-  # ansible-lint doesn't like the role name in this playbook, but it's
-  # what molecule requires
-  - molecule/default/converge.yml
   # These two are Molecule configuration files, not Ansible playbooks
   - molecule/default/molecule-no-systemd.yml
   - molecule/default/molecule-with-systemd.yml

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,7 +13,10 @@ exclude_paths:
   - .cache
   # Seems wise to ignore this too
   - .github
-  # These two are Molecule configuration files, not Ansible playbooks
-  - molecule/default/molecule-no-systemd.yml
-  - molecule/default/molecule-with-systemd.yml
+kinds:
+  # This will force our systemd specific molecule configurations to be treated
+  # as plain yaml files by ansible-lint. This mirrors the default kind
+  # configuration in ansible-lint for molecule configurations:
+  # yaml: "**/molecule/*/{base,molecule}.{yaml,yml}"
+  - yaml: "**/molecule/*/molecule-{no,with}-systemd.yml"
 use_default_rules: true


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the `ansible-lint` configuration to remove some `exclude_paths` items.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the merge of #88 we no longer need to exclude `converge.yml` files (at this time).

Previously we were excluding the `molecule-no-systemd.yml` and `molecule-with-systemd.yml` files in the `molecule/default/` directory for our [ansible-lint] configuration. This worked well enough as long as those files only existed in the `default` scenario for [molecule] and were symlinked for other scenarios. However, [cisagov/ansible-role-samba] does not have a `default` scenario, and so those files existing in a different scenario caused it to fail the `ansible-lint` hook for [pre-commit]. The change in the configuration for this type of file now brings it in line with how [ansible-lint] handles [`molecule.yml` files by default](https://github.com/ansible-community/ansible-lint/blob/5a2923d77a3c84c8e09f38a2933d07502f5f9da0/src/ansiblelint/config.py#L34). This will ensure that no matter the scenario configuration for an Ansible role project, our `systemd` configurations for [molecule] should be safely checked.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. I also made these changes in https://github.com/cisagov/ansible-role-samba/pull/3 so that it would pass tests.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

[ansible-lint]: https://github.com/ansible-community/ansible-lint
[molecule]: https://github.com/ansible-community/molecule
[pre-commit]: https://pre-commit.com
[cisagov/ansible-role-samba]: https://github.com/cisagov/ansible-role-samba