### PR TITLE
Change underscores in hostnames to hyphens

### DIFF
--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -15,70 +15,70 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: amazonlinux2_systemd
+  - name: amazonlinux2-systemd
     image: geerlingguy/docker-amazonlinux2-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: debian9_systemd
+  - name: debian9-systemd
     image: geerlingguy/docker-debian9-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: debian10_systemd
+  - name: debian10-systemd
     image: geerlingguy/docker-debian10-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: debian11_systemd
+  - name: debian11-systemd
     image: geerlingguy/docker-debian11-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: kali_systemd
+  - name: kali-systemd
     image: cisagov/docker-kali-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora32_systemd
+  - name: fedora32-systemd
     image: geerlingguy/docker-fedora32-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora33_systemd
+  - name: fedora33-systemd
     image: geerlingguy/docker-fedora33-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora34_systemd
+  - name: fedora34-systemd
     image: geerlingguy/docker-fedora34-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu_18_systemd
+  - name: ubuntu-18-systemd
     image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu_20_systemd
+  - name: ubuntu-20-systemd
     image: geerlingguy/docker-ubuntu2004-ansible:latest
     privileged: yes
     volumes:


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes the underscores that appear in hostnames to hyphens.

## 💭 Motivation and context ##

Underscores in hostnames are disallowed according to [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html) (see page 7).

Our use of underscores [is currently breaking our Kali-based Ansible role testing](https://github.com/cisagov/ansible-role-orchestrator/runs/4644951540?check_suite_focus=true#step:6:266).

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  More importantly, I verified that this sort of change resolves the broken build referenced above.  See [here](https://github.com/cisagov/ansible-role-orchestrator/actions/runs/1628320231) and [here](https://github.com/cisagov/ansible-role-orchestrator/actions/runs/1628370376)

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.