### PR TITLE
Correct the hostname that appears in the host_vars section

### DIFF
--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -96,7 +96,7 @@ provisioner:
   name: ansible
   inventory:
     host_vars:
-      debian9_systemd:
+      debian9-systemd:
         # auto_legacy is still the default behavior until Ansible 2.12
         # is released, but Molecule overrides this and forces the use
         # of auto.


### PR DESCRIPTION
## 🗣 Description ##

This pull request corrects the Debian 9 hostname that appears in the `host_vars` section of the Molecule configuration.

## 💭 Motivation and context ##

I changed the hostname above in cisagov/skeleton-ansible-role#92 but neglected to update it here.  Mea culpa.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
