### PR TITLE
Add Fedora 35, remove Fedora 32 and 33

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,9 +28,8 @@ galaxy_info:
         - bookworm
     - name: Fedora
       versions:
-        - 32
-        - 33
         - 34
+        - 35
     - name: Ubuntu
       versions:
         - bionic

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -29,12 +29,10 @@ platforms:
     image: debian:bookworm-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora32
-    image: fedora:32
-  - name: fedora33
-    image: fedora:33
   - name: fedora34
     image: fedora:34
+  - name: fedora35
+    image: fedora:35
   - name: ubuntu18
     image: ubuntu:bionic
   - name: ubuntu20

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -57,22 +57,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora32-systemd
-    image: geerlingguy/docker-fedora32-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-  - name: fedora33-systemd
-    image: geerlingguy/docker-fedora33-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
   - name: fedora34-systemd
     image: geerlingguy/docker-fedora34-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: fedora35-systemd
+    image: geerlingguy/docker-fedora35-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
## 🗣 Description ##

Add Fedora 35 to the list of supported platforms.  Remove Fedora 32 and 33.

## 💭 Motivation and context ##

Fedora 35 has been released, and we should support it.  Fedora 33 and 33 are EOL, so we need not continue to support them.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.