### PR TITLE
Add support for Fedora 36

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,7 +29,7 @@ galaxy_info:
     - name: Fedora
       versions:
         - "35"
-        - 36
+        - "36"
     - name: Ubuntu
       versions:
         - bionic

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,6 +29,7 @@ galaxy_info:
     - name: Fedora
       versions:
         - "35"
+        - 36
     - name: Ubuntu
       versions:
         - bionic

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -31,6 +31,8 @@ platforms:
     image: kalilinux/kali-rolling
   - name: fedora35
     image: fedora:35
+  - name: fedora36
+    image: fedora:36
   - name: ubuntu18
     image: ubuntu:bionic
   - name: ubuntu20

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -64,6 +64,13 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
+  - name: fedora36-systemd
+    image: geerlingguy/docker-fedora36-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
   - name: ubuntu-18-systemd
     image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: yes


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds support for Fedora 36, which was released on May 10, 2022.

~*Note that this PR cannot be merged until @geerlingguy creates a [geerlingguy/docker-fedora36-ansible](https://github.com/geerlingguy/docker-fedora36-ansible) repository (or we create our own).*~  @geerlingguy was kind enough to create the Fedora 36 Docker image, so we are good to go!

## 💭 Motivation and context ##

- Eventually Fedora 34 and Fedora 35 will be in the rearview mirror, so it is important to go ahead and start testing our Ansible roles with Fedora 36.
- We want to keep our [COOL FreeIPA AMI](https://github.com/cisagov/freeipa-server-packer) on the latest and greatest Fedora release.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.