### PR TITLE
Explicitly specify the hardware platforms for the various Molecule platforms

### DIFF
--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -17,41 +17,41 @@ lint: |
   flake8
 platforms:
   - image: amazonlinux:2
-    name: amazonlinux2-amd64
+    name: amazonlinux2
     platform: amd64
   - dockerfile: Dockerfile_debian_9.j2
     image: debian:stretch-slim
-    name: debian9-amd64
+    name: debian9
     platform: amd64
   - image: debian:buster-slim
-    name: debian10-amd64
+    name: debian10
     platform: amd64
   - image: debian:bullseye-slim
-    name: debian11-amd64
+    name: debian11
     platform: amd64
   - image: debian:bookworm-slim
-    name: debian12-amd64
+    name: debian12
     platform: amd64
   - image: kalilinux/kali-rolling
-    name: kali-amd64
+    name: kali
     platform: amd64
   - image: fedora:35
-    name: fedora35-amd64
+    name: fedora35
     platform: amd64
   - image: fedora:36
-    name: fedora36-amd64
+    name: fedora36
     platform: amd64
   - image: fedora:37
-    name: fedora37-amd64
+    name: fedora37
     platform: amd64
   - image: ubuntu:bionic
-    name: ubuntu18-amd64
+    name: ubuntu18
     platform: amd64
   - image: ubuntu:focal
-    name: ubuntu20-amd64
+    name: ubuntu20
     platform: amd64
   - image: ubuntu:jammy
-    name: ubuntu22-amd64
+    name: ubuntu22
     platform: amd64
 provisioner:
   name: ansible

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,42 +16,42 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: amazonlinux2-amd64
-    image: amazonlinux:2
+  - image: amazonlinux:2
+    name: amazonlinux2-amd64
     platform: amd64
-  - name: debian9-amd64
+  - dockerfile: Dockerfile_debian_9.j2
     image: debian:stretch-slim
-    dockerfile: Dockerfile_debian_9.j2
+    name: debian9-amd64
     platform: amd64
-  - name: debian10-amd64
-    image: debian:buster-slim
+  - image: debian:buster-slim
+    name: debian10-amd64
     platform: amd64
-  - name: debian11-amd64
-    image: debian:bullseye-slim
+  - image: debian:bullseye-slim
+    name: debian11-amd64
     platform: amd64
-  - name: debian12-amd64
-    image: debian:bookworm-slim
+  - image: debian:bookworm-slim
+    name: debian12-amd64
     platform: amd64
-  - name: kali-amd64
-    image: kalilinux/kali-rolling
+  - image: kalilinux/kali-rolling
+    name: kali-amd64
     platform: amd64
-  - name: fedora35-amd64
-    image: fedora:35
+  - image: fedora:35
+    name: fedora35-amd64
     platform: amd64
-  - name: fedora36-amd64
-    image: fedora:36
+  - image: fedora:36
+    name: fedora36-amd64
     platform: amd64
-  - name: fedora37-amd64
-    image: fedora:37
+  - image: fedora:37
+    name: fedora37-amd64
     platform: amd64
-  - name: ubuntu18-amd64
-    image: ubuntu:bionic
+  - image: ubuntu:bionic
+    name: ubuntu18-amd64
     platform: amd64
-  - name: ubuntu20-amd64
-    image: ubuntu:focal
+  - image: ubuntu:focal
+    name: ubuntu20-amd64
     platform: amd64
-  - name: ubuntu22-amd64
-    image: ubuntu:jammy
+  - image: ubuntu:jammy
+    name: ubuntu22-amd64
     platform: amd64
 provisioner:
   name: ansible

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,31 +16,43 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: amazonlinux2
+  - name: amazonlinux2-amd64
     image: amazonlinux:2
-  - name: debian9
+    platform: amd64
+  - name: debian9-amd64
     image: debian:stretch-slim
     dockerfile: Dockerfile_debian_9.j2
-  - name: debian10
+    platform: amd64
+  - name: debian10-amd64
     image: debian:buster-slim
-  - name: debian11
+    platform: amd64
+  - name: debian11-amd64
     image: debian:bullseye-slim
-  - name: debian12
+    platform: amd64
+  - name: debian12-amd64
     image: debian:bookworm-slim
-  - name: kali
+    platform: amd64
+  - name: kali-amd64
     image: kalilinux/kali-rolling
-  - name: fedora35
+    platform: amd64
+  - name: fedora35-amd64
     image: fedora:35
-  - name: fedora36
+    platform: amd64
+  - name: fedora36-amd64
     image: fedora:36
-  - name: fedora37
+    platform: amd64
+  - name: fedora37-amd64
     image: fedora:37
-  - name: ubuntu18
+    platform: amd64
+  - name: ubuntu18-amd64
     image: ubuntu:bionic
-  - name: ubuntu20
+    platform: amd64
+  - name: ubuntu20-amd64
     image: ubuntu:focal
-  - name: ubuntu22
+    platform: amd64
+  - name: ubuntu22-amd64
     image: ubuntu:jammy
+    platform: amd64
 provisioner:
   name: ansible
   inventory:

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -15,90 +15,102 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: amazonlinux2-systemd
+  - name: amazonlinux2-systemd-amd64
     image: geerlingguy/docker-amazonlinux2-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: debian9-systemd
+    platform: amd64
+  - name: debian9-systemd-amd64
     image: geerlingguy/docker-debian9-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: debian10-systemd
+    platform: amd64
+  - name: debian10-systemd-amd64
     image: geerlingguy/docker-debian10-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: debian11-systemd
+    platform: amd64
+  - name: debian11-systemd-amd64
     image: geerlingguy/docker-debian11-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: debian12-systemd
+    platform: amd64
+  - name: debian12-systemd-amd64
     image: cisagov/docker-debian12-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: kali-systemd
+    platform: amd64
+  - name: kali-systemd-amd64
     image: cisagov/docker-kali-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora35-systemd
+    platform: amd64
+  - name: fedora35-systemd-amd64
     image: geerlingguy/docker-fedora35-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora36-systemd
+    platform: amd64
+  - name: fedora36-systemd-amd64
     image: geerlingguy/docker-fedora36-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora37-systemd
+    platform: amd64
+  - name: fedora37-systemd-amd64
     image: geerlingguy/docker-fedora37-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu-18-systemd
+    platform: amd64
+  - name: ubuntu-18-systemd-amd64
     image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu-20-systemd
+    platform: amd64
+  - name: ubuntu-20-systemd-amd64
     image: geerlingguy/docker-ubuntu2004-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu-22-systemd
+    platform: amd64
+  - name: ubuntu-22-systemd-amd64
     image: geerlingguy/docker-ubuntu2204-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
+    platform: amd64
 provisioner:
   name: ansible
   inventory:

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -15,102 +15,102 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: amazonlinux2-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-amazonlinux2-ansible:latest
+    name: amazonlinux2-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: debian9-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-debian9-ansible:latest
+    name: debian9-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: debian10-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-debian10-ansible:latest
+    name: debian10-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: debian11-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-debian11-ansible:latest
+    name: debian11-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: debian12-systemd-amd64
+  - command: /lib/systemd/systemd
     image: cisagov/docker-debian12-ansible:latest
+    name: debian12-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: kali-systemd-amd64
+  - command: /lib/systemd/systemd
     image: cisagov/docker-kali-ansible:latest
+    name: kali-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: fedora35-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora35-ansible:latest
+    name: fedora35-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: fedora36-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora36-ansible:latest
+    name: fedora36-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: fedora37-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora37-ansible:latest
+    name: fedora37-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: ubuntu-18-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-ubuntu1804-ansible:latest
+    name: ubuntu-18-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: ubuntu-20-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-ubuntu2004-ansible:latest
+    name: ubuntu-20-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
-  - name: ubuntu-22-systemd-amd64
+  - command: /lib/systemd/systemd
     image: geerlingguy/docker-ubuntu2204-ansible:latest
+    name: ubuntu-22-systemd-amd64
+    platform: amd64
+    pre_build_image: yes
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-    platform: amd64
 provisioner:
   name: ansible
   inventory:

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -17,7 +17,7 @@ lint: |
 platforms:
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-amazonlinux2-ansible:latest
-    name: amazonlinux2-systemd-amd64
+    name: amazonlinux2-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -25,7 +25,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-debian9-ansible:latest
-    name: debian9-systemd-amd64
+    name: debian9-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -33,7 +33,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-amd64
+    name: debian10-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -41,7 +41,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-debian11-ansible:latest
-    name: debian11-systemd-amd64
+    name: debian11-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -49,7 +49,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: cisagov/docker-debian12-ansible:latest
-    name: debian12-systemd-amd64
+    name: debian12-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -57,7 +57,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: cisagov/docker-kali-ansible:latest
-    name: kali-systemd-amd64
+    name: kali-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -65,7 +65,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora35-ansible:latest
-    name: fedora35-systemd-amd64
+    name: fedora35-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -73,7 +73,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora36-ansible:latest
-    name: fedora36-systemd-amd64
+    name: fedora36-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -81,7 +81,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora37-ansible:latest
-    name: fedora37-systemd-amd64
+    name: fedora37-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -89,7 +89,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-ubuntu1804-ansible:latest
-    name: ubuntu-18-systemd-amd64
+    name: ubuntu-18-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -97,7 +97,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-ubuntu2004-ansible:latest
-    name: ubuntu-20-systemd-amd64
+    name: ubuntu-20-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -105,7 +105,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - command: /lib/systemd/systemd
     image: geerlingguy/docker-ubuntu2204-ansible:latest
-    name: ubuntu-22-systemd-amd64
+    name: ubuntu-22-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Molecule configurations to explicitly specify the hardware platforms for the various Molecule platforms.  In all cases, the hardware platform is `amd64`.

## 💭 Motivation and context ##

For the newer Apple hardware that runs on ARM processors, [Docker Desktop for OSX can run `arm64` (native) as well as `amd64` (emulated) Docker images](https://docs.docker.com/desktop/mac/apple-silicon/).  To ensure that our Molecule testing continues to function as expected as new ARM-based Apple hardware is rolled out, we need to explicitly specify that we want to use emulated hardware in that case.

Note that this is tangentially related to, but different from, #113.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.