### PR TITLE
Use the ansible.builtin.include_role task

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Here's how to use it in a playbook:
 - hosts: all
   become: yes
   become_method: sudo
-  roles:
-    - skeleton
+  tasks:
+    - name: Include skeleton
+      ansible.builtin.include_role:
+        name: skeleton
 ```
 
 ## New Repositories from a Skeleton ##

--- a/molecule/default/upgrade.yml
+++ b/molecule/default/upgrade.yml
@@ -3,5 +3,7 @@
   name: Upgrade base image
   become: yes
   become_method: sudo
-  roles:
-    - upgrade
+  tasks:
+    - name: Upgrade system packages
+      ansible.builtin.include_role:
+        name: upgrade


### PR DESCRIPTION
## 🗣 Description ##

This pull request adapts the code to prefer the `ansible.builtin.include_role` task to directly including Ansible roles in playbooks or playbook fragments.

## 💭 Motivation and context ##

This task is [more versatile than directly including the roles in the playbook or playbook fragment](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#id6).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.