### PR TITLE
Stop installing Python and pip in the Molecule prepare.yml playbook

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,6 +1,3 @@
 ---
 - name: Import upgrade playbook
   ansible.builtin.import_playbook: upgrade.yml
-
-- name: Import python playbook
-  ansible.builtin.import_playbook: python.yml

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,9 +1,0 @@
----
-- hosts: all
-  name: Install pip3/python3 and remove pip2/python2
-  become: yes
-  become_method: sudo
-  roles:
-    - pip
-    - python
-    - remove_python2

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,9 +1,3 @@
 ---
-- src: https://github.com/cisagov/ansible-role-pip
-  name: pip
-- src: https://github.com/cisagov/ansible-role-python
-  name: python
-- src: https://github.com/cisagov/ansible-role-remove-python2
-  name: remove_python2
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade


### PR DESCRIPTION
## 🗣 Description ##

This pull request stops installing Python and pip in the Molecule prepare.yml playbook.

## 💭 Motivation and context ##

Python and pip should instead be listed as dependencies in roles that require them.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.