### PR TITLE
Add a convenience script to update molecule Docker images

### DIFF
--- a/update_molecule_images.sh
+++ b/update_molecule_images.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Update the Docker images used in the molecule testing for this role.
+# Please note that this script requires the yq tool
+# (https://github.com/mikefarah/yq) which can be installed from brew as
+# yq and is available on Arch as go-yq.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Print usage information and exit.
+function usage {
+  echo "Usage:"
+  echo "  ${0##*/} [source_file]"
+  echo
+  echo "Arguments:"
+  echo "  source_file  If specified use this file instead of the default"
+  echo "               molecule/default/molecule.yml"
+  exit 1
+}
+
+# Check for required external programs. If any are missing output a list of all
+# requirements and then exit.
+function check_dependencies {
+  if [ -z "$(command -v yq)" ]; then
+    echo "This script requires the following tools to run:"
+    echo "- yq"
+    exit 1
+  fi
+}
+
+if [ $# -gt 1 ]; then
+  usage
+fi
+
+if [ $# -eq 1 ]; then
+  source_file="$1"
+else
+  source_file="molecule/default/molecule.yml"
+fi
+
+check_dependencies
+
+yq '.platforms[].image' < "$source_file" | xargs -n 1 docker pull


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a simple convenience script that pulls down any Docker images defined in the molecule configuration.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Sometimes you need to update your local copies of the Docker images used to test Ansible roles due to issues with older images. Manually pulling them down can be tedious so this script helps make it a simple enough affair.

### ⚠ Note ###

This script requires [yq](https://github.com/mikefarah/yq) which can be installed with [brew](https://brew.sh/) on macOS or Linux and for those of us running Arch Linux it is specifically the `go-yq` package.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I tested locally that the script works fine both with the default file and by providing a file.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
