### PR TITLE
Add support for Fedora 37

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,6 +30,7 @@ galaxy_info:
       versions:
         - "35"
         - "36"
+        - "37"
     - name: Ubuntu
       versions:
         - bionic

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -33,6 +33,8 @@ platforms:
     image: fedora:35
   - name: fedora36
     image: fedora:36
+  - name: fedora37
+    image: fedora:37
   - name: ubuntu18
     image: ubuntu:bionic
   - name: ubuntu20

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -71,6 +71,13 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
+  - name: fedora37-systemd
+    image: geerlingguy/docker-fedora37-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
   - name: ubuntu-18-systemd
     image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: yes


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds support for Fedora 37, which was released on November 15, 2022.

## 💭 Motivation and context ##

- Eventually Fedora 35 and Fedora 36 will be in the rearview mirror, so it is important to go ahead and start testing our Ansible roles with Fedora 37.
- We want to keep our [COOL FreeIPA AMI](https://github.com/cisagov/freeipa-server-packer) on the latest and greatest Fedora release.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.