### PR TITLE
Remove support for Fedora 34

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,7 +28,6 @@ galaxy_info:
         - bookworm
     - name: Fedora
       versions:
-        - "34"
         - "35"
     - name: Ubuntu
       versions:

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -29,8 +29,6 @@ platforms:
     image: debian:bookworm-slim
   - name: kali
     image: kalilinux/kali-rolling
-  - name: fedora34
-    image: fedora:34
   - name: fedora35
     image: fedora:35
   - name: ubuntu18

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -57,13 +57,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora34-systemd
-    image: geerlingguy/docker-fedora34-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
   - name: fedora35-systemd
     image: geerlingguy/docker-fedora35-ansible:latest
     privileged: yes


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes support for Fedora 34.

## 💭 Motivation and context ##

Fedora 34 is EOL as of June 7, 2022.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.