### PR TITLE
Run the molecule tests on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,9 @@ jobs:
       matrix:
         scenario:
           - default
-    runs-on: ubuntu-latest
+    # TODO: This should be changed to ubuntu-latest when possible.
+    # See issue #131 for more details.
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - id: setup-python


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the GitHub Actions workflow to run the Molecule tests under an Ubuntu 20.04 runner.

## 💭 Motivation and context ##

Amazon Linux 2 has an ancient version of SystemD (219) that doesn't support cgroups v2; therefore, we cannot run SystemD-enabled Molecule testing under Ubuntu 22.04.

Issue #131 was created to remind us to revert to running under `ubuntu-latest` (currently 22.04) when possible.

## 🧪 Testing ##

All automated tests pass.  I verified that this change results in the desired behavior by applying it to cisagov/ansible-role-amazon-ssm-agent#44.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.