### PR TITLE
Drop Amazon Linux 2 in favor of Amazon Linux 2023

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,9 +15,9 @@ galaxy_info:
   min_ansible_version: "2.10"
   namespace: cisagov
   platforms:
-    - name: Amazon
+    - name: Amazon Linux 2023
       versions:
-        - Candidate
+        - any
     - name: Debian
       versions:
         - buster

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,9 +15,9 @@ galaxy_info:
   min_ansible_version: "2.10"
   namespace: cisagov
   platforms:
-    - name: Amazon Linux 2
+    - name: Amazon
       versions:
-        - any
+        - Candidate
     - name: Debian
       versions:
         - buster

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,8 +16,8 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - image: amazonlinux:2
-    name: amazonlinux2
+  - image: amazonlinux:2023
+    name: amazonlinux2023
     platform: amd64
   - image: debian:buster-slim
     name: debian10

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -17,8 +17,8 @@ lint: |
 platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: geerlingguy/docker-amazonlinux2-ansible:latest
-    name: amazonlinux2-systemd
+    image: geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -17,7 +17,7 @@ lint: |
 platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: cisagov/docker-amazonlinux2023-ansible:latest
+    image: geerlingguy/docker-amazonlinux2023-ansible:latest
     name: amazonlinux2023-systemd
     platform: amd64
     pre_build_image: yes

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -17,7 +17,7 @@ lint: |
 platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: geerlingguy/docker-amazonlinux2023-ansible:latest
+    image: cisagov/docker-amazonlinux2023-ansible:latest
     name: amazonlinux2023-systemd
     platform: amd64
     pre_build_image: yes

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,4 @@
 ---
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade
+  version: improvement/use-detected-package-manager

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,3 @@
 ---
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade
-  version: improvement/use-detected-package-manager

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,10 @@
 # OS family.  This simplifies a lot of things for roles that support
 # Kali Linux, so it makes sense to force the installation of Ansible
 # 2.10 or newer.
-ansible>=2.10,<6
+#
+# We need at least version 6 to correctly identify Amazon Linux 2023
+# as using the dnf package manager.
+ansible>=6,<7
 ansible-lint>=5,<6
 flake8
 molecule


### PR DESCRIPTION
## 🗣 Description ##

This pull requests drops Amazon Linux 2 in favor of Amazon Linux 2023.

## 💭 Motivation and context ##

See #131.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.