### PR TITLE
Remove EOL Fedora 35 distribution

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,7 +29,6 @@ galaxy_info:
         - bookworm
     - name: Fedora
       versions:
-        - "35"
         - "36"
         - "37"
     - name: Ubuntu

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -35,9 +35,6 @@ platforms:
   - image: kalilinux/kali-rolling
     name: kali
     platform: amd64
-  - image: fedora:35
-    name: fedora35
-    platform: amd64
   - image: fedora:36
     name: fedora36
     platform: amd64

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -71,15 +71,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: geerlingguy/docker-fedora35-ansible:latest
-    name: fedora35-systemd
-    platform: amd64
-    pre_build_image: yes
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
     image: geerlingguy/docker-fedora36-ansible:latest
     name: fedora36-systemd
     platform: amd64


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the Fedora 35 distribution, which is EOL.

## 💭 Motivation and context ##

[Fedora 35 is EOL as of December 13, 2022](https://en.wikipedia.org/wiki/Fedora_Linux_release_history); furthermore, the official Fedora 35 package repositories are no longer up.  This can be seen in [this GitHub Actions run](https://github.com/cisagov/ansible-role-openjdk/actions/runs/3932982204/jobs/6726351449).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.