### PR TITLE
Pin ansible-compat

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,6 +8,9 @@
 # We need at least version 6 to correctly identify Amazon Linux 2023
 # as using the dnf package manager.
 ansible>=6,<7
+# This package currently has a bug that causes Molecule to fail.  See
+# ansible-community/molecule/issues/3903 for more details.
+ansible-compat<4
 ansible-lint>=5,<6
 flake8
 molecule


### PR DESCRIPTION
## 🗣 Description ##

This pull request pins `ansible-compat` to a version previous to version 4.

## 💭 Motivation and context ##

This is necessary because version 4 of the `ansible-compat` package contains a breaking change that causes Molecule to fail right out of the box. See ansible-community/molecule/issues/3903 for more details.

## 🧪 Testing ##

All automated tests pass with this change, but not without it.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.