### PR TITLE
Update for removal of the `lint` command in `molecule` v5

### DIFF
--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -10,11 +10,6 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint: |
-  set -e
-  yamllint .
-  ansible-lint
-  flake8
 platforms:
   - image: amazonlinux:2023
     name: amazonlinux2023

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -9,11 +9,6 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint: |
-  set -e
-  yamllint .
-  ansible-lint
-  flake8
 platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,10 +8,11 @@
 # We need at least version 6 to correctly identify Amazon Linux 2023
 # as using the dnf package manager.
 ansible>=6,<7
-ansible-lint>=5,<6
-flake8
-molecule
+# With the release of molecule v5 there were some breaking changes so
+# we need to pin at v5 or newer. However, v5.0.0 had an internal
+# dependency issue so we must use the bugfix release as the actual
+# lower bound.
+molecule>=5.0.1
 molecule-plugins[docker]
 pre-commit
 pytest-testinfra
-yamllint


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request addresses the removal of the `lint` command in [`molecule` v5](https://github.com/ansible-community/molecule/releases/tag/v5.0.0).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This sets the testing configuration to align fully with the latest version of the tools we use. Since `molecule` v5 removed the `lint` command it makes sense to pin to this latest version and remove all the elements used to support that command.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
