### PR TITLE
Remove Fedora 36 and add Fedora 38

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,8 +25,8 @@ galaxy_info:
         - bookworm
     - name: Fedora
       versions:
-        - "36"
         - "37"
+        - "38"
     - name: Kali
       versions:
         - "2023"

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -26,11 +26,11 @@ platforms:
   - image: kalilinux/kali-rolling
     name: kali
     platform: amd64
-  - image: fedora:36
-    name: fedora36
-    platform: amd64
   - image: fedora:37
     name: fedora37
+    platform: amd64
+  - image: fedora:38
+    name: fedora38
     platform: amd64
   - image: ubuntu:focal
     name: ubuntu20

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -57,8 +57,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: geerlingguy/docker-fedora36-ansible:latest
-    name: fedora36-systemd
+    image: geerlingguy/docker-fedora37-ansible:latest
+    name: fedora37-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes
@@ -66,8 +66,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: geerlingguy/docker-fedora37-ansible:latest
-    name: fedora37-systemd
+    image: geerlingguy/docker-fedora38-ansible:latest
+    name: fedora38-systemd
     platform: amd64
     pre_build_image: yes
     privileged: yes


### PR DESCRIPTION
## 🗣 Description ##

This pull request drops support for Fedora 36 and adds support for Fedora 38.

## 💭 Motivation and context ##

- [Fedora 36 is EOL as of May 16, 2023](https://docs.fedoraproject.org/en-US/releases/eol/).
- [Fedora 38 was released on April 18, 2023](https://fedoramagazine.org/announcing-fedora-38/).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.