### PR TITLE
Remove support for Ubuntu Bionic

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,7 +32,6 @@ galaxy_info:
         - "2023"
     - name: Ubuntu
       versions:
-        - bionic
         - focal
         - jammy
   role_name: skeleton

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -37,9 +37,6 @@ platforms:
   - image: fedora:37
     name: fedora37
     platform: amd64
-  - image: ubuntu:bionic
-    name: ubuntu18
-    platform: amd64
   - image: ubuntu:focal
     name: ubuntu20
     platform: amd64

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -80,15 +80,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: geerlingguy/docker-ubuntu1804-ansible:latest
-    name: ubuntu-18-systemd
-    platform: amd64
-    pre_build_image: yes
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
     image: geerlingguy/docker-ubuntu2004-ansible:latest
     name: ubuntu-20-systemd
     platform: amd64


### PR DESCRIPTION
## 🗣 Description ##

Remove support for Ubuntu Bionic.

## 💭 Motivation and context ##

[Ubuntu Bionic reached end-of-life on May 31, 2023](https://ubuntu.com/blog/ubuntu-18-04-eol-for-devices).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.