### PR TITLE
Prefer the long form of a CLI option

### DIFF
--- a/update_molecule_images.sh
+++ b/update_molecule_images.sh
@@ -42,4 +42,4 @@ fi
 
 check_dependencies
 
-yq '.platforms[].image' < "$source_file" | xargs -n 1 docker pull
+yq '.platforms[].image' < "$source_file" | xargs --max-args 1 docker pull


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies a command in a script to use the long form of a CLI option.

## 💭 Motivation and context ##

We generally prefer the long form in scripts because it makes it easier for the reader to follow along if he or she does not possess an encyclopedic knowledge of the tool being used.

## 🧪 Testing ##

- Automated tests pass.
- I ran these changes locally and confirmed that they functioned as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.