### PR TITLE
Add a standalone attribute to the role metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -35,3 +35,4 @@ galaxy_info:
         - focal
         - jammy
   role_name: skeleton
+  standalone: true


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a `standalone: true` attribute to the Ansible role metadata.

## 💭 Motivation and context ##

The addition of this attribute lets `ansible-lint` know that this is an old standalone role vice a collection.  This knowledge may allow `ansible-lint` to provide more specific warning and error messages.  See [here](https://ansible.readthedocs.io/projects/lint/rules/schema/#schemameta) for more details.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.