### PR TITLE
Add an empty meta/requirements.yml file

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,9 @@
 ---
+# Note that dependencies listed here are automatically installed
+# before this role.  Role variables for any roles listed here can be
+# assigned static variables.
+#
+# See also cisagov/skeleton-ansible-role#153.
 dependencies: []
 galaxy_info:
   author: First Last

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,0 +1,12 @@
+---
+# Note that dependencies listed here are made available to the role
+# but _are not_ automatically installed.  Role variables cannot be
+# specified here.
+#
+# It _is_ possible to list both collections and roles in this file,
+# but unfortunately ansible-galaxy attempts to naively merge the
+# dependencies listed in meta/main.yml with these.  That means that
+# both sets of dependencies must be arrays. :(
+#
+# See also cisagov/skeleton-ansible-role#153.
+[]

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -6,7 +6,7 @@
 # It _is_ possible to list both collections and roles in this file,
 # but unfortunately ansible-galaxy attempts to naively merge the
 # dependencies listed in meta/main.yml with these.  That means that
-# both sets of dependencies must be arrays. :(
+# both sets of dependencies must be lists. :(
 #
 # See also cisagov/skeleton-ansible-role#153.
 []


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request:
- Adds an empty `meta/requirements.yml` file
- Adds comments to `meta/main.yml` and `meta/requirements.yml` explaining when dependencies should be listed in one file versus the other

## 💭 Motivation and context ##

In dealing with the most recent onslaught of [cisagov/skeleton-ansible-role-with-test-user](https://github.com/cisagov/skeleton-ansible-role-with-test-user) Lineage PRs we identified several cases where we needed to pass dynamic values to role dependencies.  This required us to use the `meta/requirements.yml` file because it makes dependencies available to the role without actually installing them.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.