### PR TITLE
Expand comment to increase clarity

### DIFF
--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -5,8 +5,29 @@
 #
 # It _is_ possible to list both collections and roles in this file,
 # but unfortunately ansible-galaxy attempts to naively merge the
-# dependencies listed in meta/main.yml with these.  That means that
-# both sets of dependencies must be lists. :(
+# dependencies listed in meta/main.yml with these.  That means that if
+# the list of role dependencies in meta/main.yml is nonempty then this
+# file _must also_ consist of a single list of roles.  :(
 #
-# See also cisagov/skeleton-ansible-role#153.
+# That said, if the list of role dependencies in meta/main.yml is
+# empty, and you want to specify collection dependencies in this file,
+# then you can use the following syntax:
+# collections:
+#   - name: namespace.name
+#     signatures:
+#       - https://examplehost.com/detached_signature.asc
+#       - file:///path/to/local/detached_signature.asc
+#     type: galaxy
+#     version: 1.0.0
+#
+# roles:
+#   - name: role_name
+#     scm: git
+#     src: git@gitlab.company.com:mygroup/ansible-base.git
+#     version: 1.2.3
+#
+# See also:
+# - cisagov/skeleton-ansible-role#153
+# - https://galaxy.ansible.com/docs/using/installing.html#installing-multiple-roles-from-a-file
+# - https://docs.ansible.com/ansible/devel/collections_guide/collections_installing.html#install-multiple-collections-with-a-requirements-file
 []


### PR DESCRIPTION
## 🗣 Description ##

This pull request expands a comment to explicitly specify when it is possible to specify collections in the `meta/requirements.yml` file.  It also add links to some Ansible documentation that describes the syntax for listing role and collection dependencies.

## 💭 Motivation and context ##

I myself had to look this information up when I needed to specify a collection dependency in cisagov/ansible-role-vnc-server#48, so I thought it would be a good idea to spare future skeleton users (including me) that effort.

## 🧪 Testing ##

:eyes: 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.