### PR TITLE
Add support for Debian Trixie

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,6 +28,7 @@ galaxy_info:
         - buster
         - bullseye
         - bookworm
+        - trixie
     - name: Fedora
       versions:
         - "37"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -42,6 +42,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-kali-ansible:latest
     name: kali-systemd
     platform: amd64

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -33,7 +33,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/cisagov/docker-debian12-ansible:latest
+    image: docker.io/geerlingguy/docker-debian12-ansible:latest
     name: debian12-systemd
     platform: amd64
     pre_build_image: true


### PR DESCRIPTION
## 🗣 Description ##

Add support for Debian Trixie.  Also switch to using [geerlingguy/docker-debian12-ansible](https://github.com/geerlingguy/docker-debian12-ansible) now that it exists.

## 💭 Motivation and context ##

Debian Bookworm dropped in June, so we need to start testing on Trixie.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.