### PR TITLE
Remove mention of collections from comment

### DIFF
--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,12 +1,7 @@
 ---
-# Note that dependencies listed here are made available to the role
-# but _are not_ automatically installed.  Role variables cannot be
-# specified here.
-#
-# It _is_ possible to list both collections and roles in this file,
-# but unfortunately ansible-galaxy attempts to naively merge the
-# dependencies listed in meta/main.yml with these.  That means that
-# both sets of dependencies must be lists. :(
+# Note that role dependencies listed here are made available to the
+# role but _are not_ automatically installed.  Role variables cannot
+# be specified here.
 #
 # See also cisagov/skeleton-ansible-role#153.
 []


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the mention of adding collection dependencies to `meta/requirements.yml`.

## 💭 Motivation and context ##

`ansible-galaxy` does not appear to allow roles to depend on collections.  See [here](https://github.com/cisagov/skeleton-ansible-role/issues/153#issuecomment-1785671824) for more details.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.