### PR TITLE
Add support for Fedora 39

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
       versions:
         - "37"
         - "38"
+        - "39"
     - name: Kali
       versions:
         - "2023"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -69,6 +69,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
     name: ubuntu-20-systemd
     platform: amd64


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds support for Fedora 39.

## 💭 Motivation and context ##

Fedora 39 was released on November 7, 2023.  We need to support Fedora 39 so that [our Fedora-based FreeIPA server AMI can use a sufficiently recent version of OpenSSL](https://packages.fedoraproject.org/pkgs/openssl/openssl/) to avoid [this CVE](https://nvd.nist.gov/vuln/detail/CVE-2023-5363).

## 🧪 Testing ##

All automated tests should pass once ansible/ansible-lint#3893 is merged and the changes it contains appear in an `ansible-lint` release.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Re-run GitHub Actions checks once ansible/ansible-lint#3893 is merged and the changes it contains appear in a release.
- [x] Pin `ansible-lint` once ansible/ansible-lint#3893 is merged and the changes it contains appears in a release.