### PR TITLE
Remove the Fedora 37 platform

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,7 +30,6 @@ galaxy_info:
         - bookworm
     - name: Fedora
       versions:
-        - "37"
         - "38"
     - name: Kali
       versions:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -51,15 +51,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-fedora37-ansible:latest
-    name: fedora37-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora38-ansible:latest
     name: fedora38-systemd
     platform: amd64


### PR DESCRIPTION
## 🗣 Description ##

This pull request drops support for Fedora 37.

## 💭 Motivation and context ##

[Fedora 37 is EOL as of December 5, 2023](https://docs.fedoraproject.org/en-US/releases/eol/).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.