### PR TITLE
Allow ansible versions greater than 6

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,8 +6,14 @@
 # 2.10 or newer.
 #
 # We need at least version 6 to correctly identify Amazon Linux 2023
-# as using the dnf package manager.
-ansible>=6,<7
+# as using the dnf package manager, and version 8 is currently the
+# oldest supported version.
+#
+# We have tested against version 9.  We want to avoid automatically
+# jumping to another major version without testing, since there are
+# often breaking changes across major versions.  This is the reason
+# for the upper bound.
+ansible>=8,<10
 # With the release of molecule v5 there were some breaking changes so
 # we need to pin at v5 or newer. However, v5.0.0 had an internal
 # dependency issue so we must use the bugfix release as the actual


### PR DESCRIPTION
## 🗣 Description ##

This pull request removed the upper bound on the version of Ansible installed.

## 💭 Motivation and context ##

Ansible 9 appears to function without issue.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.