### PR TITLE
Add `arm64` platforms to Molecule configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
       - dependency-name: mxschmitt/action-tmate
       - dependency-name: step-security/harden-runner
       # # Managed by cisagov/skeleton-ansible-role
+      # - dependency-name: docker/setup-buildx-action
+      # - dependency-name: docker/setup-qemu-action
       # - dependency-name: github/codeql-action
     package-ecosystem: github-actions
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,8 +175,8 @@ jobs:
       fail-fast: false
       matrix:
         architecture:
-          - aarch64
           - amd64
+          - arm64
         platform:
           - amazonlinux2023-systemd
           - debian10-systemd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Run molecule tests
         run: molecule test --scenario-name ${{ matrix.scenario }}
       - name: Setup tmate debug session

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,15 +177,6 @@ jobs:
         architecture:
           - aarch64
           - amd64
-        exclude:
-          # The Docker images we use for these platforms do not
-          # support aarch64.
-          - architecture: aarch64
-            platform: amazonlinux2023-systemd
-          - architecture: aarch64
-            platform: fedora39-systemd
-          - architecture: aarch64
-            platform: fedora40-systemd
         platform:
           - amazonlinux2023-systemd
           - debian10-systemd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        architecture:
+          - aarch64
+          - amd64
+        exclude:
+          # The Docker images we use for these platforms do not
+          # support aarch64.
+          - architecture: aarch64
+            platform: amazonlinux2023-systemd
+          - architecture: aarch64
+            platform: fedora39-systemd
+          - architecture: aarch64
+            platform: fedora40-systemd
+        platform:
+          - amazonlinux2023-systemd
+          - debian10-systemd
+          - debian11-systemd
+          - debian12-systemd
+          - debian13-systemd
+          - kali-systemd
+          - fedora39-systemd
+          - fedora40-systemd
+          - ubuntu-20-systemd
+          - ubuntu-22-systemd
+          - ubuntu-24-systemd
         scenario:
           - default
     steps:
@@ -209,7 +233,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run molecule tests
-        run: molecule test --scenario-name ${{ matrix.scenario }}
+        run: >-
+          molecule test
+          --platform-name ${{ matrix.platform }}-${{ matrix.architecture }}
+          --scenario-name ${{ matrix.scenario }}
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,9 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   test:
+    name: >-
+      test (${{ matrix.scenario }}) -
+      ${{ matrix.platform }}-${{ matrix.architecture }}
     needs:
       - diagnostics
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,9 +192,9 @@ jobs:
           - debian11-systemd
           - debian12-systemd
           - debian13-systemd
-          - kali-systemd
           - fedora39-systemd
           - fedora40-systemd
+          - kali-systemd
           - ubuntu-20-systemd
           - ubuntu-22-systemd
           - ubuntu-24-systemd

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,16 +13,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # There is no aarch64 version of this Docker image.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
-  #   name: amazonlinux2023-systemd-aarch64
-  #   platform: aarch64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd-aarch64
+    platform: aarch64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian10-ansible:latest
@@ -122,16 +121,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # There is no aarch64 version of this Docker image.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora39-ansible:latest
-  #   name: fedora39-systemd-aarch64
-  #   platform: aarch64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd-aarch64
+    platform: aarch64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora40-ansible:latest
@@ -141,16 +139,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # There is no aarch64 version of this Docker image.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora40-ansible:latest
-  #   name: fedora40-systemd-aarch64
-  #   platform: aarch64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora40-ansible:latest
+    name: fedora40-systemd-aarch64
+    platform: aarch64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,26 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
-    name: amazonlinux2023-systemd
+    name: amazonlinux2023-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # There is no aarch64 version of this Docker image.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
+  #   name: amazonlinux2023-systemd-aarch64
+  #   platform: aarch64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian10-ansible:latest
+    name: debian10-systemd-amd64
     platform: amd64
     pre_build_image: true
     privileged: true
@@ -16,7 +35,16 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd
+    name: debian10-systemd-aarch64
+    platform: aarch64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian11-ansible:latest
+    name: debian11-systemd-amd64
     platform: amd64
     pre_build_image: true
     privileged: true
@@ -25,7 +53,16 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian11-ansible:latest
-    name: debian11-systemd
+    name: debian11-systemd-aarch64
+    platform: aarch64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian12-ansible:latest
+    name: debian12-systemd-amd64
     platform: amd64
     pre_build_image: true
     privileged: true
@@ -34,7 +71,16 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian12-ansible:latest
-    name: debian12-systemd
+    name: debian12-systemd-aarch64
+    platform: aarch64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd-amd64
     platform: amd64
     pre_build_image: true
     privileged: true
@@ -43,7 +89,16 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-debian13-ansible:latest
-    name: debian13-systemd
+    name: debian13-systemd-aarch64
+    platform: aarch64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-kali-ansible:latest
+    name: kali-systemd-amd64
     platform: amd64
     pre_build_image: true
     privileged: true
@@ -52,8 +107,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-kali-ansible:latest
-    name: kali-systemd
-    platform: amd64
+    name: kali-systemd-aarch64
+    platform: aarch64
     pre_build_image: true
     privileged: true
     volumes:
@@ -61,16 +116,45 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora39-ansible:latest
-    name: fedora39-systemd
+    name: fedora39-systemd-amd64
     platform: amd64
     pre_build_image: true
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # There is no aarch64 version of this Docker image.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+  #   name: fedora39-systemd-aarch64
+  #   platform: aarch64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora40-ansible:latest
-    name: fedora40-systemd
+    name: fedora40-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # There is no aarch64 version of this Docker image.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-fedora40-ansible:latest
+  #   name: fedora40-systemd-aarch64
+  #   platform: aarch64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
+    name: ubuntu-20-systemd-amd64
     platform: amd64
     pre_build_image: true
     privileged: true
@@ -79,7 +163,16 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
-    name: ubuntu-20-systemd
+    name: ubuntu-20-systemd-aarch64
+    platform: aarch64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
+    name: ubuntu-22-systemd-amd64
     platform: amd64
     pre_build_image: true
     privileged: true
@@ -88,7 +181,16 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
-    name: ubuntu-22-systemd
+    name: ubuntu-22-systemd-aarch64
+    platform: aarch64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
+    name: ubuntu-24-systemd-amd64
     platform: amd64
     pre_build_image: true
     privileged: true
@@ -97,8 +199,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
-    name: ubuntu-24-systemd
-    platform: amd64
+    name: ubuntu-24-systemd-aarch64
+    platform: aarch64
     pre_build_image: true
     privileged: true
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,8 +16,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
-    name: amazonlinux2023-systemd-aarch64
-    platform: aarch64
+    name: amazonlinux2023-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -34,8 +34,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd-aarch64
-    platform: aarch64
+    name: debian10-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -52,8 +52,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian11-ansible:latest
-    name: debian11-systemd-aarch64
-    platform: aarch64
+    name: debian11-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -70,8 +70,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian12-ansible:latest
-    name: debian12-systemd-aarch64
-    platform: aarch64
+    name: debian12-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -88,8 +88,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-debian13-ansible:latest
-    name: debian13-systemd-aarch64
-    platform: aarch64
+    name: debian13-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -106,8 +106,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-kali-ansible:latest
-    name: kali-systemd-aarch64
-    platform: aarch64
+    name: kali-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -124,8 +124,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora39-ansible:latest
-    name: fedora39-systemd-aarch64
-    platform: aarch64
+    name: fedora39-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -142,8 +142,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora40-ansible:latest
-    name: fedora40-systemd-aarch64
-    platform: aarch64
+    name: fedora40-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -160,8 +160,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
-    name: ubuntu-20-systemd-aarch64
-    platform: aarch64
+    name: ubuntu-20-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -178,8 +178,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
-    name: ubuntu-22-systemd-aarch64
-    platform: aarch64
+    name: ubuntu-22-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:
@@ -196,8 +196,8 @@ platforms:
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
-    name: ubuntu-24-systemd-aarch64
-    platform: aarch64
+    name: ubuntu-24-systemd-arm64
+    platform: arm64
     pre_build_image: true
     privileged: true
     volumes:

--- a/update_molecule_images.sh
+++ b/update_molecule_images.sh
@@ -45,4 +45,4 @@ check_dependencies
 # Note that we can't use --max-args in place of -n in the xargs
 # command since the version of xargs distributed with macOS does not
 # support it.
-yq '.platforms[].image' < "$source_file" | xargs -n 1 docker pull
+yq '.platforms[] | "\(.platform) \(.image)"' < "$source_file" | xargs -n 2 docker pull --platform


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds `arm64` platforms to our Molecule testing.

## 💭 Motivation and context ##

We need to test our Ansible roles on `arm64` so that we can migrate to Graviton instances.

## 🧪 Testing ##

Automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.