### PR TITLE
Pin `ansible-core` to earlier than 2.16.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@ updates:
     # ignore:
     #   # Managed by cisagov/skeleton-ansible-role
     #   - dependency-name: ansible
+    #   - dependency-name: ansible-core
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -21,7 +21,7 @@ ansible>=8,<10
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.
 #
-# See also cisagov/skeleton-packer##312.
+# See also cisagov/skeleton-packer#312.
 ansible-core<2.16.3
 # With the release of molecule v5 there were some breaking changes so
 # we need to pin at v5 or newer. However, v5.0.0 had an internal

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,6 +14,15 @@
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
 ansible>=8,<10
+# TODO: Remove this pin when possible.  See
+# cisagov/skeleton-ansible-role#178 for more details.
+#
+# ansible-core 2.16.3 and later suffer from the bug discussed in
+# ansible/ansible#82702, which breaks any symlinked files in vars,
+# tasks, etc. for any Ansible role installed via ansible-galaxy.
+#
+# See also cisagov/skeleton-packer##312.
+ansible-core<2.16.3
 # With the release of molecule v5 there were some breaking changes so
 # we need to pin at v5 or newer. However, v5.0.0 had an internal
 # dependency issue so we must use the bugfix release as the actual


### PR DESCRIPTION
## 🗣 Description ##

This pull request pins the `ansible-core` Python package's version to earlier than 2.16.3.

## 💭 Motivation and context ##

`ansible-core` 2.16.3 and later suffer from the bug discussed in ansible/ansible#82702, which breaks any symlinked files in `vars`, `tasks`, etc. for any Ansible role installed via `ansible-galaxy`.  This results, e.g., in [AMI build failures](https://github.com/cisagov/openvpn-packer/actions/runs/8205777362/job/22446435052) as seen in cisagov/openvpn-packer#101.

## 🧪 Testing ##

All automated testing passes in this pull request, and in cisagov/openvpn-packer#101 the build [gets further than it did upon addition of a similar change](https://github.com/cisagov/openvpn-packer/actions/runs/8208824296/job/22453124370?pr=101) via cisagov/skeleton-packer#311.  (The build continues to fail, but for a different reason.)

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.