### PR TITLE
Remove needless Dependabot ignore directive

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,6 @@ updates:
     # ignore:
     #   # Managed by cisagov/skeleton-ansible-role
     #   - dependency-name: ansible
-    #   - dependency-name: ansible-lint
     package-ecosystem: pip
     schedule:
       interval: weekly


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes a now-unnecessary Dependabot ignore directive.

## 💭 Motivation and context ##

The pin against `ansible-lint` was removed in commit 32993325e11d482e078e05d27c3269e6401a8f53, so there is no longer any need for the Dependabot ignore directive.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.