### PR TITLE
Remove duplicated instance of "ansible-galaxy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ None.
 This role can be installed via the command:
 
 ```console
-ansible-galaxy ansible-galaxy install --role-file path/to/requirements.yml
+ansible-galaxy install --role-file path/to/requirements.yml
 ```
 
 where `requirements.yml` looks like:


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a typo where "ansible-galaxy" was duplicated.

## 💭 Motivation and context ##

Our documentation should be correct.

## 🧪 Testing ##

I used my ocular orbs to check that the changes look correct.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.