### PR TITLE
Change the license so that it is an SPDX string

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
   description: Skeleton Ansible role
   galaxy_tags:
     - skeleton
-  license: CC0
+  license: CC0-1.0
   # With the release of version 2.10, Ansible finally correctly
   # identifies Kali Linux as being the Kali distribution of the Debian
   # OS family.  This simplifies a lot of things for roles that support


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the license entry in the role metadata so that it is an SPDX string.

## 💭 Motivation and context ##

This is [what is expected by Ansible Galaxy](https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.