### PR TITLE
Add support for Fedora 40

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,8 +31,8 @@ galaxy_info:
         - trixie
     - name: Fedora
       versions:
-        - "38"
         - "39"
+        - "40"
     - name: Kali
       versions:
         - "2023"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -60,8 +60,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-fedora38-ansible:latest
-    name: fedora38-systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd
     platform: amd64
     pre_build_image: true
     privileged: true
@@ -69,8 +69,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
-    name: fedora39-systemd
+    image: docker.io/geerlingguy/docker-fedora40-ansible:latest
+    name: fedora40-systemd
     platform: amd64
     pre_build_image: true
     privileged: true


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds support for Fedora 40 and drops support for Fedora 38.

## 💭 Motivation and context ##

Fedora 40 was recently released and Fedora 38 is now EOL.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.