### PR TITLE
Update version pin on `ansible-core` Python package

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,15 +14,15 @@
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
 ansible>=8,<10
-# TODO: Remove this pin when possible.  See
-# cisagov/skeleton-ansible-role#178 for more details.
-#
-# ansible-core 2.16.3 and later suffer from the bug discussed in
+# ansible-core 2.16.3 through 2.16.6 suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.
+# Hence we never want to install those versions.
 #
-# See also cisagov/skeleton-packer#312.
-ansible-core<2.16.3
+# Note that any changes made to this dependency must also be made in
+# requirements.txt in cisagov/skeleton-packer and
+# .pre-commit-config.yaml in cisagov/skeleton-generic.
+ansible-core>=2.16.7
 # With the release of molecule v5 there were some breaking changes so
 # we need to pin at v5 or newer. However, v5.0.0 had an internal
 # dependency issue so we must use the bugfix release as the actual

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,7 +13,7 @@
 # jumping to another major version without testing, since there are
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
-ansible>=8,<10
+ansible>=9,<10
 # ansible-core 2.16.3 through 2.16.6 suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the current version pin on the `ansible-core` Python package, replacing it with a lower bound that guarantees we will never use the problematic versions.

## 💭 Motivation and context ##

We can do this because new versions of the `ansible-core` Python package (2.16.7 and 2.17.0) have been released that do not suffer from the bug discussed in ansible/ansible#82702. This bug broke any symlinked files in vars, tasks, etc. for any Ansible role installed via `ansible-galaxy`.

Resolves #178.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.