### PR TITLE
Add a lower-bound pin for `pytest-testinfra`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,7 @@ updates:
     #   - dependency-name: ansible
     #   - dependency-name: ansible-core
     #   - dependency-name: molecule
+    #   - dependency-name: pytest-testinfra
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -30,4 +30,6 @@ ansible-core>=2.16.7
 molecule>=5.0.1
 molecule-plugins[docker]
 pre-commit
-pytest-testinfra
+# pytest-testinfra 10.1.1 contains a fix for SystemdService.exists
+# that is required by some roles' Molecule test code.
+pytest-testinfra>=10.1.1


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a lower-bound pin for `pytest-testinfra`.

## 💭 Motivation and context ##

We do this because `pytest-testinfra` 10.1.1 contains a fix for `SystemdService.exists` that is required by [some roles' Molecule test code](https://github.com/cisagov/ansible-role-systemd-resolved/pull/8#discussion_r1652096342).

Note that we also add a corresponding line to the Dependabot configuration so that descendant repos know this dependency is managed here.

## 🧪 Testing ##

All automated tests pass.  See also cisagov/ansible-role-systemd-resolved#8.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.