### PR TITLE
Add support for Fedora 41

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,7 @@ jobs:
           - debian13-systemd
           - fedora39-systemd
           - fedora40-systemd
+          - fedora41-systemd
           - kali-systemd
           - ubuntu-20-systemd
           - ubuntu-22-systemd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,7 +155,7 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint
-    rev: v24.6.0
+    rev: v24.10.0
     hooks:
       - id: ansible-lint
         additional_dependencies:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -33,6 +33,7 @@ galaxy_info:
       versions:
         - "39"
         - "40"
+        - "41"
     - name: Kali
       versions:
         - "2023"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -150,6 +150,24 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora41-ansible:latest
+    name: fedora41-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora41-ansible:latest
+    name: fedora41-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
     name: ubuntu-20-systemd-amd64
     platform: amd64

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -9,4 +9,3 @@ collections:
 roles:
   - name: upgrade
     src: https://github.com/cisagov/ansible-role-upgrade
-    version: feature/add-support-for-dnf5

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -9,3 +9,4 @@ collections:
 roles:
   - name: upgrade
     src: https://github.com/cisagov/ansible-role-upgrade
+    version: feature/add-support-for-dnf5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,20 +9,27 @@
 # as using the dnf package manager, and version 8 is currently the
 # oldest supported version.
 #
-# We have tested against version 9.  We want to avoid automatically
+# Version 10 is required because the pip-audit pre-commit hook
+# identifies a vulnerability in ansible-core 2.16.13, but all versions
+# of ansible 9 have a dependency on ~=2.16.X.
+#
+# We have tested against version 10.  We want to avoid automatically
 # jumping to another major version without testing, since there are
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
-ansible>=9,<10
+ansible>=10,<11
 # ansible-core 2.16.3 through 2.16.6 suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.
 # Hence we never want to install those versions.
 #
+# Note that the pip-audit pre-commit hook identifies a vulnerability
+# in ansible-core 2.16.13.
+#
 # Note that any changes made to this dependency must also be made in
 # requirements.txt in cisagov/skeleton-packer and
 # .pre-commit-config.yaml in cisagov/skeleton-generic.
-ansible-core>=2.16.7
+ansible-core>2.16.13
 # With the release of molecule v5 there were some breaking changes so
 # we need to pin at v5 or newer. However, v5.0.0 had an internal
 # dependency issue so we must use the bugfix release as the actual


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds support for Fedora 41.

> [!NOTE]  
> This pull request is built on top of #209 and hence that pull request must be merged before this one.

> [!NOTE]  
> I `git cherry-pick`ed cisagov/skeleton-generic@b9f798d03afb72f33ffa625982dd5b548dea5132 from cisagov/skeleton-generic#197 onto this pull request because it needs that version of the `ansible-lint` `pre-commit` hook in order to pass linting.

## 💭 Motivation and context ##

[Fedora 41 was released on October 29th](https://www.redhat.com/en/blog/announcing-fedora-41), so we should support it.  We are also [moving our FreeIPA server AMI to Fedora 41](https://github.com/cisagov/freeipa-server-packer#129).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert to using the default branch of [cisagov/ansible-role-upgrade](https://github.com/cisagov/ansible-role-upgrade) once cisagov/ansible-role-upgrade#66 has been merged.
- [x] Mark the Fedora 41 checks as required.