### PR TITLE
Bump up the lower bound on `ansible-core`

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,20 +9,27 @@
 # as using the dnf package manager, and version 8 is currently the
 # oldest supported version.
 #
-# We have tested against version 9.  We want to avoid automatically
+# Version 10 is required because the pip-audit pre-commit hook
+# identifies a vulnerability in ansible-core 2.16.13, but all versions
+# of ansible 9 have a dependency on ~=2.16.X.
+#
+# We have tested against version 10.  We want to avoid automatically
 # jumping to another major version without testing, since there are
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
-ansible>=9,<10
+ansible>=10,<11
 # ansible-core 2.16.3 through 2.16.6 suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.
 # Hence we never want to install those versions.
 #
+# Note that the pip-audit pre-commit hook identifies a vulnerability
+# in ansible-core 2.16.13.
+#
 # Note that any changes made to this dependency must also be made in
 # requirements.txt in cisagov/skeleton-packer and
 # .pre-commit-config.yaml in cisagov/skeleton-generic.
-ansible-core>=2.16.7
+ansible-core>2.16.13
 # With the release of molecule v5 there were some breaking changes so
 # we need to pin at v5 or newer. However, v5.0.0 had an internal
 # dependency issue so we must use the bugfix release as the actual

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,6 +13,10 @@
 # identifies a vulnerability in ansible-core 2.16.13, but all versions
 # of ansible 9 have a dependency on ~=2.16.X.
 #
+# It is also a good idea to go ahead and upgrade to version 10 since
+# version 9 is going EOL at the end of November:
+# https://endoflife.date/ansible
+#
 # We have tested against version 10.  We want to avoid automatically
 # jumping to another major version without testing, since there are
 # often breaking changes across major versions.  This is the reason
@@ -27,6 +31,10 @@ ansible>=10,<11
 # in ansible-core 2.16.13.  Normally we would pin ansible-core
 # accordingly (>2.16.13), but the above pin of ansible>=10 effectively
 # pins ansible-core to >=2.17 so that's what we do here.
+#
+# It is also a good idea to go ahead and upgrade to ansible-core 2.17
+# since security support for ansible-core 2.16 ends this month:
+# https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
 #
 # Note that any changes made to this dependency must also be made in
 # requirements.txt in cisagov/skeleton-packer and

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -24,12 +24,14 @@ ansible>=10,<11
 # Hence we never want to install those versions.
 #
 # Note that the pip-audit pre-commit hook identifies a vulnerability
-# in ansible-core 2.16.13.
+# in ansible-core 2.16.13.  Normally we would pin ansible-core
+# accordingly (>2.16.13), but the above pin of ansible>=10 effectively
+# pins ansible-core to >=2.17 so that's what we do here.
 #
 # Note that any changes made to this dependency must also be made in
 # requirements.txt in cisagov/skeleton-packer and
 # .pre-commit-config.yaml in cisagov/skeleton-generic.
-ansible-core>2.16.13
+ansible-core>=2.17
 # With the release of molecule v5 there were some breaking changes so
 # we need to pin at v5 or newer. However, v5.0.0 had an internal
 # dependency issue so we must use the bugfix release as the actual


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the lower bound on the `ansible-core` Python package.

See also cisagov/skeleton-generic#196 and the commits cisagov/skeleton-packer@26a8bafe25f49a099a07342a1539e4dd6eb60095 and cisagov/skeleton-packer@19fbaf3e1a6da801ce796509b8187ff1aa541d43 in cisagov/skeleton-packer#376.

Supplants #208.

## 💭 Motivation and context ##

This is being done because the `pip-audit` `pre-commit` hook identifies a vulnerability in `ansible-core` version 2.16.13.  Note that this requires that we bump up the version of `ansible` to version 10 since all versions of `ansible` 9 have a dependency on `ansible-core~=2.16.X`.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.