### PR TITLE
Stop ignoring `pip-audit` vulnerability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -185,35 +185,20 @@ repos:
           # additional dependency, with the same pinning as is done in
           # requirements-test.txt of cisagov/skeleton-ansible-role.
           #
-          # Version 10 is required because the pip-audit pre-commit
-          # hook identifies a vulnerability in ansible-core 2.16.13,
-          # but all versions of ansible 9 have a dependency on
-          # ~=2.16.X.
-          #
-          # It is also a good idea to go ahead and upgrade to version
-          # 10 since version 9 is going EOL at the end of November:
-          # https://endoflife.date/ansible
-          # - ansible>=10,<11
-          # ansible-core 2.16.3 through 2.16.6 suffer from the bug
-          # discussed in ansible/ansible#82702, which breaks any
-          # symlinked files in vars, tasks, etc. for any Ansible role
-          # installed via ansible-galaxy.  Hence we never want to
-          # install those versions.
-          #
+          # Version 11 is required because the pip-audit pre-commit
+          # hook identifies a vulnerability (GHSA-99w6-3xph-cx78) in
+          # ansible-core<=2.18.0, but all versions of ansible 10 have a
+          # dependency on ~=2.17.X.
+          # - ansible>=11,<12
           # Note that the pip-audit pre-commit hook identifies a
-          # vulnerability in ansible-core 2.16.13.  The pin of
-          # ansible-core to >=2.17 effectively also pins ansible to
-          # >=10.
-          #
-          # It is also a good idea to go ahead and upgrade to
-          # ansible-core 2.17 since security support for ansible-core
-          # 2.16 ends this month:
-          # https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+          # vulnerability (GHSA-99w6-3xph-cx78) in ansible-core
+          # 2.18.0.  The pin of ansible-core to >=2.18.1 effectively
+          # also pins ansible to >=11.
           #
           # Note that any changes made to this dependency must also be
           # made in requirements.txt in cisagov/skeleton-packer and
           # requirements-test.txt in cisagov/skeleton-ansible-role.
-          - ansible-core>=2.17
+          - ansible-core>=2.18.1
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,11 +154,6 @@ repos:
     hooks:
       - id: pip-audit
         args:
-          # We have to ignore this particular vulnerability in
-          # ansible-core>=2.11 as there is currently no fix.  See
-          # cisagov/skeleton-ansible-role#210 for more details.
-          - --ignore-vuln
-          - GHSA-99w6-3xph-cx78
           # Add any pip requirements files to scan
           - --requirement
           - requirements-dev.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,45 +1,22 @@
 --requirement requirements.txt
-# With the release of version 2.10, Ansible finally correctly
-# identifies Kali Linux as being the Kali distribution of the Debian
-# OS family.  This simplifies a lot of things for roles that support
-# Kali Linux, so it makes sense to force the installation of Ansible
-# 2.10 or newer.
+# Version 11 is required because the pip-audit pre-commit hook
+# identifies a vulnerability (GHSA-99w6-3xph-cx78) in
+# ansible-core<=2.18.0, but all versions of ansible 10 have a
+# dependency on ~=2.17.X.
 #
-# We need at least version 6 to correctly identify Amazon Linux 2023
-# as using the dnf package manager, and version 8 is currently the
-# oldest supported version.
-#
-# Version 10 is required because the pip-audit pre-commit hook
-# identifies a vulnerability in ansible-core 2.16.13, but all versions
-# of ansible 9 have a dependency on ~=2.16.X.
-#
-# It is also a good idea to go ahead and upgrade to version 10 since
-# version 9 is going EOL at the end of November:
-# https://endoflife.date/ansible
-#
-# We have tested against version 10.  We want to avoid automatically
+# We have tested against version 11.  We want to avoid automatically
 # jumping to another major version without testing, since there are
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
-ansible>=10,<11
-# ansible-core 2.16.3 through 2.16.6 suffer from the bug discussed in
-# ansible/ansible#82702, which breaks any symlinked files in vars,
-# tasks, etc. for any Ansible role installed via ansible-galaxy.
-# Hence we never want to install those versions.
-#
+ansible>=11,<12
 # Note that the pip-audit pre-commit hook identifies a vulnerability
-# in ansible-core 2.16.13.  Normally we would pin ansible-core
-# accordingly (>2.16.13), but the above pin of ansible>=10 effectively
-# pins ansible-core to >=2.17 so that's what we do here.
-#
-# It is also a good idea to go ahead and upgrade to ansible-core 2.17
-# since security support for ansible-core 2.16 ends this month:
-# https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+# (GHSA-99w6-3xph-cx78) in ansible-core 2.18.0.  The pin of
+# ansible-core to >=2.18.1 effectively also pins ansible to >=11.
 #
 # Note that any changes made to this dependency must also be made in
 # requirements.txt in cisagov/skeleton-packer and
 # .pre-commit-config.yaml in cisagov/skeleton-generic.
-ansible-core>=2.17
+ansible-core>=2.18.1
 # With the release of molecule v5 there were some breaking changes so
 # we need to pin at v5 or newer. However, v5.0.0 had an internal
 # dependency issue so we must use the bugfix release as the actual


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes the necessary changes so that we can stop ignoring a vulnerability in `ansible-core` identified by `pip-audit`:
- Pull in upstream changes from cisagov/skeleton-generic#199.
- Copy upstream changes from cisagov/skeleton-generic#199 over to `requirements-test.txt`.
- Remove command line option that forced the `pip-audit` `pre-commit` hook to ignore an `ansible-core` vulnerability.

> [!NOTE]  
> This pull request pulls in commit https://github.com/cisagov/skeleton-generic/pull/199/commits/5f0190ce52ef9a81d5b8def52393b933168a1520 from cisagov/skeleton-generic#199.

## 💭 Motivation and context ##

Vulnerabilities should not be ignored if they need not be.  Resolves #210.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.