### PR TITLE
Use native ARM runners when testing on ARM architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,13 +200,10 @@ jobs:
         scenario:
           - default
     steps:
-      # With this task in place the GitHub runners run out of
-      # resources and crash.  See cisagov/skeleton-ansible-role#211
-      # for more details.
-      # - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      #   with:
-      #     # Uses the organization variable unless overridden
-      #     config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          # Uses the organization variable unless overridden
+          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: harden-runner
         name: Harden the runner
         uses: step-security/harden-runner@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
     permissions:
       # actions/checkout needs this to fetch code
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-${{ startsWith(matrix.architecture, 'arm') && '24.04-arm' || 'latest' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Modifies the `build.yml` workflow to use native ARM runners when testing on ARM architecture
- Reinstates the [GitHubSecurityLab/actions-permissions/monitor](https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor) GitHub action

## 💭 Motivation and context ##

- This provides better and faster testing of ARM architectures than using QEMU emulation.
- We are no longer emulating ARM under QEMU, so using this GitHub Action no longer causes the runners to run out of resources and crash.

Resolves #211.

## 🧪 Testing ##

All automated tests pass.  I also verified that the expected platforms are indeed tested via native ARM runners.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.