### PR TITLE
Disable `unix-chkpwd` AppArmor profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,9 +271,12 @@ jobs:
           molecule test
           --platform-name ${{ matrix.platform }}-${{ matrix.architecture }}
           --scenario-name ${{ matrix.scenario }}
+      # TODO: Remove the apt-get install command when possible.  See
+      # cisagov/skeleton-ansible-role#215 for more details.
       - name: Re-enable unix-chkpwd AppArmor profile
-        run: >-
+        run: |
           sudo aa-enforce /usr/sbin/unix_chkpwd
+          sudo apt-get install firefox passt
         if: ${{ startsWith(matrix.platform, 'fedora') }}
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,11 +238,43 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      # Disabling the unix-chkpwd AppArmor profile is necessary when
+      # running Molecule tests against Fedora 40 and 41; otherwise,
+      # the privileged container cannot successfully run sudo and
+      # hence Ansible is unable to do anything.  See
+      # fedora-cloud/docker-brew-fedora#117 for more details.
+      #
+      # Purging firefox is currently necessary because the
+      # installation available on the GitHub runner instance provides
+      # two conflicting AppArmor profiles:
+      # /etc/apparmor.d/usr.bin.firefox and /etc/apparmor.d/firefox.
+      # This conflict causes the aa-disable /usr/sbin/unix_chkpwd
+      # command to fail.
+      #
+      # Purging passt is currently necessary because the installation
+      # available on the GitHub runner instance contains a wonky
+      # AppArmor file (/etc/apparmor.d/abstractions/passt) that causes
+      # the aa-disable command to fail.
+      #
+      # TODO: Remove the apt-get purge and systemctl reload commands
+      # when possible.  See cisagov/skeleton-ansible-role#215 for more
+      # details.
+      - name: Disable unix-chkpwd AppArmor profile
+        run: |
+          sudo apt-get purge firefox passt
+          sudo systemctl reload apparmor.service
+          sudo apt-get install apparmor-utils
+          sudo aa-disable /usr/sbin/unix_chkpwd
+        if: ${{ startsWith(matrix.platform, 'fedora') }}
       - name: Run molecule tests
         run: >-
           molecule test
           --platform-name ${{ matrix.platform }}-${{ matrix.architecture }}
           --scenario-name ${{ matrix.scenario }}
+      - name: Re-enable unix-chkpwd AppArmor profile
+        run: >-
+          sudo aa-enforce /usr/sbin/unix_chkpwd
+        if: ${{ startsWith(matrix.platform, 'fedora') }}
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE


### PR DESCRIPTION
## 🗣 Description ##

This pull request disables the `unix-chkpwd` AppArmor profile before running Molecule tests against Fedora Docker containers.

## 💭 Motivation and context ##

This is necessary when running Molecule tests against Fedora 40 and 41; otherwise, the privileged container cannot successfully execute `sudo` and hence Ansible is unable to do anything.

Note that this change is reverted after the Molecule tests are run.

For now, disabling the `unix-chkpwd` AppArmor profile also requires an `apt-get purge` of the `firefox` and `passt` packages.  It should be possible to remove this purge (and the ensuing `systemctl reload apparmor.service`) at a future date.  See cisagov/skeleton-ansible-role#215 for more details.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.