### PR TITLE
List as a requirement the Ansible role to be tested by Molecule

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Include skeleton-ansible-role
+    - name: Include cisagov/skeleton-ansible-role
       ansible.builtin.include_role:
-        name: skeleton-ansible-role
+        name: skeleton

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -7,5 +7,7 @@ collections:
     version: ">=3.10.2"
 
 roles:
+  - name: skeleton
+    src: https://github.com/cisagov/skeleton-ansible-role
   - name: upgrade
     src: https://github.com/cisagov/ansible-role-upgrade

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -40,11 +40,9 @@ ansible>=10,<11
 # requirements.txt in cisagov/skeleton-packer and
 # .pre-commit-config.yaml in cisagov/skeleton-generic.
 ansible-core>=2.17
-# With the release of molecule v5 there were some breaking changes so
-# we need to pin at v5 or newer. However, v5.0.0 had an internal
-# dependency issue so we must use the bugfix release as the actual
-# lower bound.
-molecule>=5.0.1
+# With the release of molecule v25.2 the role being tested must be
+# specified in requirements.yml.
+molecule>=25.2.0
 molecule-plugins[docker]
 pre-commit
 # pytest-testinfra 10.1.1 contains a fix for SystemdService.exists


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Specifies the role to be tested by Molecule in `requirements.yml`.
- Pins Molecule to 25.2.0 or later.

## 💭 Motivation and context ##

- This is required as of Molecule 25.2.0.
- This is a breaking change, so it will not work with earlier versions of Molecule.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.