### PR TITLE
Pin Molecule to <25.2.0

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -44,7 +44,15 @@ ansible-core>=2.17
 # we need to pin at v5 or newer. However, v5.0.0 had an internal
 # dependency issue so we must use the bugfix release as the actual
 # lower bound.
-molecule>=5.0.1
+#
+# TODO: As of molecule v25.2.0, molecule no longer adds the current
+# project directory to the search path for Ansible roles.  This breaks
+# our current molecule testing, since Ansible does not find the local
+# copy of the role being tested.  For now, it makes sense to pin to
+# <25.2.0 until we figure out how to deal with this change.  This
+# upper-bound pin should be removed when possible.  See
+# cisagov/skeleton-ansible-role#219 for more details.
+molecule>=5.0.1,<25.2.0
 molecule-plugins[docker]
 pre-commit
 # pytest-testinfra 10.1.1 contains a fix for SystemdService.exists


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a pin to restrict `molecule` to `<25.2.0`.

This upper-bound pin should be removed when possible.  See #219 for more details.

## 💭 Motivation and context ##

As of `molecule` v25.2.0, Molecule no longer adds the current project directory to the search path for Ansible roles.  This breaks our current Molecule testing, since Ansible does not find the local copy of the role being tested.  For now, it makes sense to pin `molecule` to `<25.2.0` until we figure out how to deal with this change.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.