### PR TITLE
Define `ANSIBLE_ROLES_PATH` for the `ansible` provisioner

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -220,6 +220,10 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: ~/.cache/molecule/skeleton-ansible-role/${MOLECULE_SCENARIO_NAME}/roles:${MOLECULE_PROJECT_DIRECTORY}/..:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 scenario:
   name: default
 verifier:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -223,6 +223,11 @@ platforms:
 provisioner:
   name: ansible
   env:
+    # Molecule used to add ${MOLECULE_PROJECT_DIRECTORY}/. to this
+    # path for us pre-25.2.0, but now we have to do it ourselves.  See
+    # ansible/molecule#4380 and
+    # https://github.com/ansible/molecule/releases/tag/v25.2.0 for
+    # more details.
     ANSIBLE_ROLES_PATH: ~/.cache/molecule/skeleton-ansible-role/${MOLECULE_SCENARIO_NAME}/roles:${MOLECULE_PROJECT_DIRECTORY}/..:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 scenario:
   name: default


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `molecule.yml` file to define the `ANSIBLE_ROLES_PATH` environment variable, inserting the path to the repository checkout directory.

## 💭 Motivation and context ##

`molecule` used to modify the roles path for us, but as of v25.2.0 no longer does.  (See ansible/molecule#4380 for details.)  As a result we must now modify it ourselves.

Without this change `molecule` can no longer find the `skeleton-ansible-role` Ansible role.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.