### PR TITLE
Disable AppArmor before running Molecule tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       - dependency-name: hashicorp/setup-terraform
       - dependency-name: mxschmitt/action-tmate
       # # Managed by cisagov/skeleton-ansible-role
+      # - dependency-name: cisagov/action-disable-apparmor
       # - dependency-name: docker/setup-buildx-action
       # - dependency-name: docker/setup-qemu-action
       # - dependency-name: github/codeql-action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,7 +295,7 @@ jobs:
       # future, it makes sense to simply disable AppArmor altogether
       # before running Molecule tests.
       - name: Disable AppArmor
-        uses: cisagov/action-disable-apparmor@first-commits
+        uses: cisagov/action-disable-apparmor@v1
       - name: Run molecule tests
         run: >-
           molecule test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,46 +283,24 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      # Disabling the unix-chkpwd AppArmor profile is necessary when
-      # running Molecule tests against Fedora 40 and 41; otherwise,
-      # the privileged container cannot successfully run sudo and
-      # hence Ansible is unable to do anything.  See
+      # AppArmor interferes when running Molecule tests against Fedora
+      # 40 and 41; it does not allow the privileged container to run
+      # sudo and hence Ansible is unable to do anything.  See
       # fedora-cloud/docker-brew-fedora#117 for more details.
       #
-      # Purging firefox is currently necessary because the
-      # installation available on the GitHub runner instance provides
-      # two conflicting AppArmor profiles:
-      # /etc/apparmor.d/usr.bin.firefox and /etc/apparmor.d/firefox.
-      # This conflict causes the aa-disable /usr/sbin/unix_chkpwd
-      # command to fail.
-      #
-      # Purging passt is currently necessary because the installation
-      # available on the GitHub runner instance contains a wonky
-      # AppArmor file (/etc/apparmor.d/abstractions/passt) that causes
-      # the aa-disable command to fail.
-      #
-      # TODO: Remove the apt-get purge and systemctl reload commands
-      # when possible.  See cisagov/skeleton-ansible-role#215 for more
-      # details.
-      - name: Disable unix-chkpwd AppArmor profile
-        run: |
-          sudo apt-get purge firefox passt
-          sudo systemctl reload apparmor.service
-          sudo apt-get install apparmor-utils
-          sudo aa-disable /usr/sbin/unix_chkpwd
-        if: ${{ startsWith(matrix.platform, 'fedora') }}
+      # There is a growing consensus that AppArmor causes too many
+      # problems and should not be active on the short-lived GitHub
+      # runners.  See, for example,
+      # actions/runner-images/issues/10015.  To avoid problems in the
+      # future, it makes sense to simply disable AppArmor altogether
+      # before running Molecule tests.
+      - name: Disable AppArmor
+        uses: cisagov/action-disable-apparmor@first-commits
       - name: Run molecule tests
         run: >-
           molecule test
           --platform-name ${{ matrix.platform }}-${{ matrix.architecture }}
           --scenario-name ${{ matrix.scenario }}
-      # TODO: Remove the apt-get install command when possible.  See
-      # cisagov/skeleton-ansible-role#215 for more details.
-      - name: Re-enable unix-chkpwd AppArmor profile
-        run: |
-          sudo aa-enforce /usr/sbin/unix_chkpwd
-          sudo apt-get install firefox passt
-        if: ${{ startsWith(matrix.platform, 'fedora') }}
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `build.yml` workflow to leverage [cisagov/action-disable-apparmor](https://github.com/cisagov/action-disable-apparmor) to disable AppArmor before running the Molecule tests.

## 💭 Motivation and context ##

This is a better (less janky) solution to the AppArmor woes than cisagov/skeleton-ansible-role#216.  We are also already taxing the free GitHub runners, and I have seen failures in the steps added in cisagov/skeleton-ansible-role#216.  This solution should tax the runners a bit less.

It is also worth noting that lot of folks (me included) are [of the opinion that AppArmor shouldn't be enabled in the GitHub runners](https://github.com/actions/runner-images/issues/10015).

Resolves #215.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Use the `v1` tag of [cisagov/action-disable-apparmor](https://github.com/cisagov/action-disable-apparmor) once cisagov/action-disable-apparmor#1 is approved and merged.