### PR TITLE
Add `.ansible` directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Files already tracked by Git are not affected.
 # See: https://git-scm.com/docs/gitignore
 
+## Ansible ##
+.ansible
+
 ## Python ##
 __pycache__
 .mypy_cache


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the `.ansible` directory located at the root of the project to `.gitignore`.

## 💭 Motivation and context ##

Ansible tools now save any downloaded roles, collections, and modules to an `.ansible` directory located at the root of the project directory.  (This is a new feature of `ansible-compat`.)  This cache directory should be ignored by `git`.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.