### PR TITLE
Remove step to setup QEMU

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,6 @@ updates:
       - dependency-name: mxschmitt/action-tmate
       # # Managed by cisagov/skeleton-ansible-role
       # - dependency-name: docker/setup-buildx-action
-      # - dependency-name: docker/setup-qemu-action
       # - dependency-name: github/codeql-action
     package-ecosystem: github-actions
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,8 +279,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       # Disabling the unix-chkpwd AppArmor profile is necessary when


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the step in the `build.yml` workflow that sets up QEMU.

## 💭 Motivation and context ##

We no longer use QEMU when testing Ansible roles now that we are able to use ARM-native GHA runners.

In rare cases where GHA runners are resource-constrained and crashing (see, e.g., cisagov/ansible-role-cyhy-reports#82) this can also free up some resources and make the GHA checks pass.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.