### PR TITLE
Add support for Fedora 42

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -132,6 +132,24 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora42-ansible:latest
+    name: fedora42-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora42-ansible:latest
+    name: fedora42-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
     name: ubuntu-22-systemd-amd64
     platform: amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,6 +222,7 @@ jobs:
           - debian12-systemd
           - debian13-systemd
           - fedora41-systemd
+          - fedora42-systemd
           - kali-systemd
           - ubuntu-22-systemd
           - ubuntu-24-systemd

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
     - name: Fedora
       versions:
         - "41"
+        - "42"
     - name: Kali
       versions:
         - "2023"


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds support for Fedora 42.

## 💭 Motivation and context ##

Fedora 42 was released on April 15, 2025.

See also cisagov/skeleton-generic#210.  This pull request should pass its GH Actions checks once that pull request is merged and flows down through our [Lineage](https://github.com/cisagov/action-lineage) process.

## 🧪 Testing ##

All automated tests pass, except for the linters.  This is because `ansible-lint` does not yet support Fedora 42 in the schema.  ansible/ansible-lint#4583 was created for this, so this pull request should pass the linters once:
- [x] ansible/ansible-lint#4583 is merged.
- [x] A new release of `ansible-lint` is created.  (See [here](https://github.com/ansible/ansible-lint/releases/tag/v25.4.0).)
- [x] cisagov/skeleton-generic#210 is merged.
- [x] The changes in cisagov/skeleton-generic#210 flow down to this repository via our [Lineage](https://github.com/cisagov/action-lineage) process.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Mark Fedora 42 checks as required.
