### PR TITLE
Use @geerlingguy's Debian Trixie Docker image

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -78,7 +78,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/cisagov/docker-debian13-ansible:latest
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
     name: debian13-systemd-amd64
     platform: amd64
     pre_build_image: true
@@ -87,7 +87,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
-    image: docker.io/cisagov/docker-debian13-ansible:latest
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
     name: debian13-systemd-arm64
     platform: arm64
     pre_build_image: true


### PR DESCRIPTION
He has one now that Trixie has been officially released.

## 🗣 Description ##

This pull request amends the `molecule` configuration to use @geerlingguy's Debian Trixie Docker image.

## 💭 Motivation and context ##

We use his Docker images when they are available, and he has one for Debian Trixie now that it has been officially released.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.