### PR TITLE
Fix the helper script that updates Docker images used in our Molecule configuration

### DIFF
--- a/update_molecule_images.sh
+++ b/update_molecule_images.sh
@@ -9,6 +9,8 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+DEFAULT_SOURCE_FILE=".config/molecule/config.yml"
+
 # Print usage information and exit.
 function usage {
   echo "Usage:"
@@ -16,7 +18,7 @@ function usage {
   echo
   echo "Arguments:"
   echo "  source_file  If specified use this file instead of the default"
-  echo "               .config/molecule/config.yml"
+  echo "               $DEFAULT_SOURCE_FILE"
   exit 1
 }
 
@@ -37,7 +39,7 @@ fi
 if [ $# -eq 1 ]; then
   source_file="$1"
 else
-  source_file=".config/molecule/config.yml"
+  source_file="$DEFAULT_SOURCE_FILE"
 fi
 
 check_dependencies

--- a/update_molecule_images.sh
+++ b/update_molecule_images.sh
@@ -16,7 +16,7 @@ function usage {
   echo
   echo "Arguments:"
   echo "  source_file  If specified use this file instead of the default"
-  echo "               molecule/default/molecule.yml"
+  echo "               .config/molecule/config.yml"
   exit 1
 }
 
@@ -37,7 +37,7 @@ fi
 if [ $# -eq 1 ]; then
   source_file="$1"
 else
-  source_file="molecule/default/molecule.yml"
+  source_file=".config/molecule/config.yml"
 fi
 
 check_dependencies


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the helper script for updating the Docker images used in our Molecule configuration to use the correct default value.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When I was checking #237 I realized that the script was never updated for the changes in #222. While fixing that I also DRYed things out a bit by using a variable for the default file path.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the script works when called and also that the usage information displays the correct information.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
