### PR TITLE
Make the `bandit` `pre-commit` hook useful again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,15 +128,27 @@ repos:
       - id: shellcheck
 
   # Python hooks
+  # Run bandit on the Molecule tests
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.6
     hooks:
       - id: bandit
-        # Bandit complains about the use of assert() in tests. This should cover
-        # the tests/ subdirectory for any molecule scenario.
-        exclude: molecule/[^/]+/tests
+        name: bandit (Molecule tests)
+        files: molecule/[^/]+/tests
         args:
-          - --config=.bandit.yml
+          # Skip "assert used" check since assertions are used
+          # frequently in pytests.
+          - --skip=B101
+  # Run bandit on everything except the Molecule tests
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.6
+    hooks:
+      - id: bandit
+        name: bandit (everything else)
+        # Bandit complains about the use of assert() in tests. This
+        # should cover the tests/ subdirectory for any molecule
+        # scenario.
+        exclude: molecule/[^/]+/tests
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.1.0
     hooks:


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the `pre-commit` configuration to run `bandit` against the `molecule` scenario test code.

## 💭 Motivation and context ##

Previously the hook was not being run at all against the `molecule` test code, which is often the only Python code in these Ansible role repos.

Resolves #244.

## 🧪 Testing ##

All automated checks pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.