### PR TITLE
Use the same version of the `bandit` `pre-commit` hook everywhere

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,7 +141,7 @@ repos:
           - --skip=B101
   # Run bandit on everything except the Molecule tests
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.6
+    rev: 1.9.1
     hooks:
       - id: bandit
         name: bandit (everything else)


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a bug so that the same version of the `bandit` `pre-commit` hook is used everywhere.

## 💭 Motivation and context ##

Consistency!

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.