### PR TITLE
Add a Docker volume at `/var/lib/containerd`

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -14,6 +14,7 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /var/lib/containerd
 
   - &common_arm64_platform_config
     <<: *common_amd64_platform_config


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a Docker volume at `/var/lib/containerd` for all platforms tested via `molecule`.

## 💭 Motivation and context ##

This is necessary because of the [new `containerd` snapshotters](https://github.com/docker/cli/issues/6646#issuecomment-3518152318).  Note that the volume that has to be created is at [`/var/lib/containerd` instead of `/var/lib/docker`](https://github.com/docker/cli/issues/6646#issuecomment-3830743220).  I confirmed that this is also the correct location for Amazon Linux 2023, Fedora 42, and Fedora 43.

## 🧪 Testing ##

All automated tests pass.  See also cisagov/ansible-role-guacamole#86.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.