### PR TITLE
Add a comment to explain the presence of the `/var/lib/containerd` volume

### DIFF
--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -14,6 +14,12 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      # This is necessary because of the new containerd
+      # snapshotters[1].  Note that the volume that has to be created
+      # is at /var/lib/containerd instead of /var/lib/docker[2].
+      #
+      # [1]: https://github.com/docker/cli/issues/6646#issuecomment-3518152318
+      # [2]: https://github.com/docker/cli/issues/6646#issuecomment-3830743220
       - /var/lib/containerd
 
   - &common_arm64_platform_config


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a comment to explain the presence of the `/var/lib/containerd` volume.

## 💭 Motivation and context ##

This should have been done in #254 but was not.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.