### PR TITLE
Upgrade the `docker/setup-buildx-action` action to `v4`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,7 +289,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade --requirement requirements-test.txt
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       # AppArmor interferes when running Molecule tests against Fedora
       # 40 and 41; it does not allow the privileged container to run
       # sudo and hence Ansible is unable to do anything.  See


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action) GitHub action from `v3` to `v4`.

## 💭 Motivation and context ##

`v4` was released back in March.  I'm not sure why Dependabot never created a PR for this.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.