### PR TITLE
Remove Ubuntu Focal from list of platforms

### DIFF
--- a/molecule/default/externally-managed-python.yml
+++ b/molecule/default/externally-managed-python.yml
@@ -10,7 +10,7 @@
     - name: Ensure Python is marked as externally managed
       when:
         - ansible_distribution in ["Debian", "Ubuntu"]
-        - ansible_distribution_release not in ["bullseye", "buster", "focal", "jammy"]
+        - ansible_distribution_release not in ["bullseye", "buster", "jammy"]
       block:
         - name: Gather package facts
           ansible.builtin.package_facts:


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes Ubuntu Focal from a list of platforms.

## 💭 Motivation and context ##

We no longer support Ubuntu Focal as it is EOL.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
