### PR TITLE
Prepend `linux/` to the platform in the Docker image update script

### DIFF
--- a/update_molecule_images.sh
+++ b/update_molecule_images.sh
@@ -46,5 +46,7 @@ check_dependencies
 
 # Note that we can't use --max-args in place of -n in the xargs
 # command since the version of xargs distributed with macOS does not
-# support it.
-yq '.platforms[] | "\(.platform) \(.image)"' < "$source_file" | xargs -n 2 docker pull --platform
+# support it. We must prepend `linux/` to the platform because on macOS (with
+# Colima) it will prepend `darwin/` by default and that results in an error when
+# attempting to pull the images.
+yq '.platforms[] | "linux/\(.platform) \(.image)"' < "$source_file" | xargs -n 2 docker pull --platform


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `update_molecule_images.sh` script to prepend `linux/` to the platform when pulling Docker images.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When running this script in macOS using [Colima] you get errors like this:
```console
Error response from daemon: no matching manifest for darwin/amd64 in the manifest list entries: no match for platform in manifest: not found
```

Prepending `linux/` successfully pulls down the images and testing works as expected.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that Docker images pull as expected on my MacBook.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
